### PR TITLE
implement fuzzy search with fuse

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@tailwindcss/vite": "^4.2.2",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
+        "fuse.js": "^7.3.0",
         "lucide-react": "^1.8.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -275,6 +276,8 @@
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "fuse.js": ["fuse.js@7.3.0", "", {}, "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@tailwindcss/vite": "^4.2.2",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",
+    "fuse.js": "^7.3.0",
     "lucide-react": "^1.8.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import {listen} from "@tauri-apps/api/event";
 import "./App.css";
@@ -7,12 +7,15 @@ import { Header } from "./components/Header";
 import { Library } from "./components/Library";
 import { PlayerBar } from "./components/PlayerBar";
 import { usePlayer } from "./hooks/usePlayer";
+import { filterDirs } from "./utils/filterDirs";
 
 function App() {
   const [scanMeta, setScanMeta] = useState<ScanMetaData | null>(null);
   const [dirs, setDirs] = useState<Directory[]>([]);
   const [query, setQuery] = useState('');
   const [scanState, setScanState] = useState<ScanState>('idle');
+
+  const filteredDirs = useMemo(() => filterDirs(dirs, query), [dirs, query])
 
   useEffect(() => {
     setScanState('scanning')
@@ -50,7 +53,7 @@ function App() {
     scanMeta={scanMeta}
   />
   <Library
-  scanState={scanState}  currentTrack={currentTrack} dirs={dirs} onPlay={play} query={query} />
+  scanState={scanState}  currentTrack={currentTrack} dirs={filteredDirs} onPlay={play} query={query} />
   
   <PlayerBar 
     track={currentTrack}

--- a/src/components/Library.tsx
+++ b/src/components/Library.tsx
@@ -10,29 +10,10 @@ interface LibraryProps {
   scanState: ScanState
 }
 
-function filterDirs(dirs: Directory[], query: string): Directory[] {
-  if (!query) return dirs
-  const q = query.toLowerCase()
 
-  return dirs.reduce<Directory[]>((acc, dir) => {
-    const filteredFiles = dir.files.filter(f =>
-      f.name.toLowerCase().includes(q)
-    )
-    const filteredAlbums = dir.albums.reduce<typeof dir.albums>((aalc, album) => {
-      const files = album.files.filter(f => f.name.toLowerCase().includes(q))
-      if (files.length > 0) aalc.push({ ...album, files })
-      return aalc
-    }, [])
-
-    if (filteredFiles.length > 0 || filteredAlbums.length > 0) {
-      acc.push({ ...dir, files: filteredFiles, albums: filteredAlbums })
-    }
-    return acc
-  }, [])
-}
 
 export function Library({ dirs, query, currentTrack, onPlay, scanState }: LibraryProps) {
-  const filtered = filterDirs(dirs, query)
+  const filtered = dirs
 
 
  if (scanState === 'scanning' && dirs.length === 0) {

--- a/src/utils/filterDirs.ts
+++ b/src/utils/filterDirs.ts
@@ -1,0 +1,71 @@
+import Fuse from 'fuse.js'
+import { Directory, MediaFile } from '../types'
+
+export function filterDirs(dirs: Directory[], query: string): Directory[] {
+  if (!query) return dirs
+
+  // flatten all files with directory/album context for fuse
+  type IndexedFile = {
+    file: MediaFile
+    dirName: string
+    albumName: string | null
+  }
+
+  const indexed: IndexedFile[] = dirs.flatMap(dir => [
+    ...dir.files.map(f => ({ file: f, dirName: dir.name, albumName: null })),
+    ...dir.albums.flatMap(album =>
+      album.files.map(f => ({ file: f, dirName: dir.name, albumName: album.name }))
+    )
+  ])
+
+  const fuse = new Fuse(indexed, {
+    keys: [
+      { name: 'file.name', weight: 2 },
+      { name: 'albumName', weight: 1 },
+      { name: 'dirName', weight: 0.5 }
+    ],
+    threshold: 0.4,
+    ignoreLocation: true,
+    minMatchCharLength: 2,
+  })
+
+  const results = fuse.search(query).map(r => r.item)
+
+  // rebuild directory structure from results
+  const dirMap = new Map<string, Directory>()
+
+  for (const { file, dirName, albumName } of results) {
+    if (!dirMap.has(dirName)) {
+      const original = dirs.find(d => d.name === dirName)
+      if (!original) continue
+      dirMap.set(dirName, {
+        name: original.name,
+        path: original.path,
+        files: [],
+        albums: [],
+      })
+    }
+
+    const dir = dirMap.get(dirName)!
+
+    if (albumName) {
+      let album = dir.albums.find(a => a.name === albumName)
+      if (!album) {
+        album = { name: albumName, files: [] }
+        dir.albums.push(album)
+      }
+      album.files.push(file)
+    } else {
+      dir.files.push(file)
+    }
+  }
+
+  return Array.from(dirMap.values())
+}
+
+export function flattenFiles(dirs: Directory[]): MediaFile[] {
+  return dirs.flatMap(dir => [
+    ...dir.files,
+    ...dir.albums.flatMap(album => album.files)
+  ])
+}


### PR DESCRIPTION
## Summary

Replaces substring matching in the search feature with fuzzy matching using `fuse.js`.
Users can now find tracks despite typos, partial queries, or word reordering.

## Motivation

Previously, `filterDirs` used `String.prototype.includes` for matching:

```ts
dir.files.filter(f => f.name.toLowerCase().includes(q))
```

This required the query to match a contiguous substring of the filename, which is
unforgiving for real-world searches. Searching `"sadows"` would not find
`"ShadowsAndDust.mp3"`, and `"shadow dust"` would not find it either since the
words are not in that exact order in the filename.

## Changes

### Added
- `fuse.js` dependency
- Fuzzy search implementation in `src/utils/filterDirs.ts` with weighted keys:
  - filename (weight 2)
  - album name (weight 1)
  - directory name (weight 0.5)
- `threshold: 0.4` for moderate fuzziness tolerance
- `ignoreLocation: true` so matches anywhere in the string rank equally
- `minMatchCharLength: 2` to avoid noisy single-character matches

### Changed
- `filterDirs` now flattens the directory tree into an indexable list, runs Fuse
  search, and rebuilds the tree from results rather than filtering in-place
- `Library.tsx` no longer calls `filterDirs` internally — filtering is lifted to
  `App.tsx` via `useMemo` and the filtered result is passed down as the `dirs` prop
- `usePlayer` continues to receive the unfiltered `dirs` so track navigation
  (next/prev) still cycles through the full library regardless of active search

### Removed
- `String.prototype.includes` substring matching in `filterDirs`
- Internal `filterDirs` call inside `Library.tsx`

## Examples

| Query | Before | After |
|---|---|---|
| `sadows` | no results | matches `ShadowsAndDust.mp3` |
| `shadow dust` | no results | matches `ShadowsAndDust.mp3` |
| `porcl` | no results | matches `Porcelain.mp3` |
| `bart skils` | matches `Bart Skils - Your Mind.mp3` | matches (unchanged) |

## Performance

Fuse builds a new index per search, which is acceptable for libraries up to a few
thousand tracks. If performance degrades on larger libraries, the Fuse index can
be memoized in `App.tsx` and passed down — left as a future enhancement.

## Testing

- Verified fuzzy matches for typos (`sadows` → `Shadows`)
- Verified word reordering (`shadow dust` → `ShadowsAndDust`)
- Verified partial matches still work (`bart` → `Bart Skils`)
- Verified empty query returns full library unchanged
- Verified track navigation (next/prev) ignores search filter

## Related
- Closes #XX (fuzzy search issue)