### PR TITLE
13 performance optimization read metadata in parallel while scanning for media

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.bat text eol=crlf
+*.ps1 text eol=crlf

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -684,12 +684,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2084,32 +2078,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lofty"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8bc4717ff10833a623b009e9254ae8667c7a59edc3cfb01c37aeeef4b6d54a7"
-dependencies = [
- "byteorder",
- "data-encoding",
- "flate2",
- "lofty_attr",
- "log",
- "ogg_pager",
- "paste",
-]
-
-[[package]]
-name = "lofty_attr"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9983e64b2358522f745c1251924e3ab7252d55637e80f6a0a3de642d6a9efc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2435,15 +2403,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ogg_pager"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b0bef808533c5890ab77279538212efdbbbd9aa4ef1ccdfcfbf77a42f7e6fa"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2530,12 +2489,6 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
@@ -2764,7 +2717,6 @@ name = "playmusic"
 version = "0.1.0"
 dependencies = [
  "dirs 5.0.1",
- "lofty",
  "md5",
  "rayon",
  "serde",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -565,6 +565,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,6 +881,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embed-resource"
@@ -2741,6 +2766,7 @@ dependencies = [
  "dirs 5.0.1",
  "lofty",
  "md5",
+ "rayon",
  "serde",
  "serde_json",
  "symphonia",
@@ -3014,6 +3040,26 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,4 +27,4 @@ dirs = "5"
 md5 = "0.7"
 lofty = "0.21"
 symphonia = { version = "0.5", features = ["mp3", "aac", "flac", "ogg", "wav", "isomp4"] }
-
+rayon = "1"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,6 +25,5 @@ serde_json = "1"
 walkdir = "2"
 dirs = "5"
 md5 = "0.7"
-lofty = "0.21"
 symphonia = { version = "0.5", features = ["mp3", "aac", "flac", "ogg", "wav", "isomp4"] }
 rayon = "1"

--- a/src-tauri/src/scanner.rs
+++ b/src-tauri/src/scanner.rs
@@ -3,8 +3,6 @@ use walkdir::WalkDir;
 use std::io::{Read, Seek, SeekFrom};
 use std::collections::HashMap;
 use tauri::Emitter;
-use lofty::probe::Probe;
-use lofty::prelude::AudioFile;
 use rayon::prelude::*;
 
 
@@ -71,7 +69,7 @@ fn partial_hash(path: &str) -> Option<String> {
     Some(format!("{:x}", md5::compute(&buf)))
 }
 
-fn read_duration(path: &str) -> f64 {
+/*fn read_duration(path: &str) -> f64 {
     // purkka ratkaisu isoihin tiedostoihin: jos yli 500mb, ei laske kestoa
     let size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
     if size > 500 * 1024 * 1024 {
@@ -84,7 +82,7 @@ fn read_duration(path: &str) -> f64 {
         .and_then(|f| f.read().ok())
         .map(|t| t.properties().duration().as_secs_f64())
         .unwrap_or(0.0)
-}
+}*/
 
 fn read_size(path: &str) -> u64 {
     std::fs::metadata(path).map(|m| m.len()).unwrap_or(0)
@@ -149,7 +147,7 @@ pub async fn scan_media(app: tauri::AppHandle) -> ScanResult {
         let processed_chunk: Vec<(Entry, MediaFile, Option<String>)> = chunk
             .par_iter()
             .map(|entry| {
-                let duration_secs = read_duration(&entry.path);
+                let duration_secs = 0.0;
                 let size_bytes = read_size(&entry.path);
                 let hash = partial_hash(&entry.path);
 

--- a/src-tauri/src/scanner.rs
+++ b/src-tauri/src/scanner.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use tauri::Emitter;
 use lofty::probe::Probe;
 use lofty::prelude::AudioFile;
+use rayon::prelude::*;
 
 
 
@@ -47,6 +48,16 @@ pub struct ScanResult {
     duplicates: Vec<Vec<String>>
 }
 
+struct Entry {
+    path: String,
+    name: String,
+    ext: String,
+    top: String,
+    album: Option<String>
+}
+
+
+
 fn partial_hash(path: &str) -> Option<String> {
     let mut file = std::fs::File::open(path).ok()?;
     let mut buf = vec![0u8; 4096];
@@ -61,6 +72,12 @@ fn partial_hash(path: &str) -> Option<String> {
 }
 
 fn read_duration(path: &str) -> f64 {
+    // purkka ratkaisu isoihin tiedostoihin: jos yli 500mb, ei laske kestoa
+    let size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+    if size > 500 * 1024 * 1024 {
+        return 0.0;
+    }
+
     Probe::open(path)
         .ok()
         .and_then(|p| p.guess_file_type().ok())
@@ -78,123 +95,170 @@ pub async fn scan_media(app: tauri::AppHandle) -> ScanResult {
     let start = std::time::Instant::now();
     let audio_ext = ["mp3", "flac", "wav", "aac", "ogg"];
     let video_ext = ["mp4", "mkv", "webm", "avi", "mov"];
-
+    let allowed_dirs = ["Downloads", "Music", "Videos", "Desktop", "Documents"];
     let home = dirs::home_dir().unwrap_or(PathBuf::from("/"));
 
-    let mut groups: HashMap<String, Directory> = HashMap::new();
-    let mut seen: HashMap<String, Vec<String>> = HashMap::new();
-    let mut file_count = 0;
-
-    WalkDir::new(&home)
+    // phase 1 — single-threaded walk to collect entries
+    let entries: Vec<Entry> = WalkDir::new(&home)
         .min_depth(1)
         .max_depth(4)
         .into_iter()
         .filter_map(|e| e.ok())
         .filter(|e| e.file_type().is_file())
-       .for_each(|e| {
-            let ext = match e.path()
+        .filter_map(|e| {
+            let ext = e.path()
                 .extension()
                 .and_then(|x| x.to_str())
-                .map(|x| x.to_lowercase())
-            {
-                Some(x) if audio_ext.contains(&x.as_str()) || video_ext.contains(&x.as_str()) => x,
-                _ => return,
-            };
+                .map(|x| x.to_lowercase())?;
 
-            let rel = e.path().strip_prefix(&home).unwrap();
+            if !audio_ext.contains(&ext.as_str()) && !video_ext.contains(&ext.as_str()) {
+                return None;
+            }
+
+            let rel = e.path().strip_prefix(&home).ok()?;
             let parts: Vec<_> = rel.components().collect();
-            if parts.len() < 2 { return; }
+            if parts.len() < 2 { return None; }
 
             let top = parts[0].as_os_str().to_string_lossy().to_string();
+            if !allowed_dirs.contains(&top.as_str()) { return None; }
 
-            // skip dirs not in whitelist
-            let allowed_dirs = ["Downloads", "Music", "Videos", "Desktop", "Documents"];
-            if !allowed_dirs.contains(&top.as_str()) { return; }
+            let album = if parts.len() >= 3 {
+                Some(parts[1].as_os_str().to_string_lossy().to_string())
+            } else {
+                None
+            };
 
-            let file = MediaFile {
+            Some(Entry {
                 path: e.path().to_string_lossy().to_string(),
                 name: e.file_name().to_string_lossy().to_string(),
                 ext,
-                duration_secs: read_duration(e.path().to_str().unwrap_or("")),
-                size_bytes: read_size(e.path().to_str().unwrap_or(""))
-            };
+                top,
+                album,
+            })
+        })
+        .collect();
 
-            if let Some(hash) = partial_hash(e.path().to_str().unwrap_or("")) {
-                let paths = seen.entry(hash).or_insert_with(Vec::new);
-                // if we've already seen this hash, skip adding to groups entirely
-                if !paths.is_empty() {
-                    paths.push(e.path().to_string_lossy().to_string());
-                    return;
-                }
-                paths.push(e.path().to_string_lossy().to_string());
-            }
-            if parts.len() >= 3 {
-                let album = parts[1].as_os_str().to_string_lossy().to_string();
-                let group = groups.entry(top.clone()).or_insert(Directory {
-                    name: top.clone(),
-                    path: home.join(&top).to_string_lossy().to_string(),
-                    albums: Vec::new(),
-                    files: Vec::new(),
-                });
-                if let Some(alb) = group.albums.iter_mut().find(|a| a.name == album) {
-                    alb.files.push(file);
-                } else {
-                    group.albums.push(Album { name: album, files: vec![file] });
-                }
-            } else {
-                let group = groups.entry(top.clone()).or_insert(Directory {
-                    name: top.clone(),
-                    path: home.join(&top).to_string_lossy().to_string(),
-                    albums: Vec::new(),
-                    files: Vec::new(),
-                });
-                group.files.push(file);
-            }
-            file_count += 1;
+    // phase 2 — process in parallel chunks, emit progress between chunks
+    let chunk_size = 50;
+    let mut groups: HashMap<String, Directory> = HashMap::new();
+    let mut seen: HashMap<String, Vec<String>> = HashMap::new();
 
-            if file_count % 10 == 0 {
-                let mut current: Vec<&Directory> = groups.values().collect();
-                current.sort_by(|a, b| a.name.cmp(&b.name));
-                app.emit("scan_progress", &current).ok();
-            }
-        });
 
-        let mut directories: Vec<Directory> = groups.into_values().collect();
-        directories.sort_by(|a, b| a.name.cmp(&b.name));
+    println!("total entries collected: {}", entries.len());
+    for chunk in entries.chunks(chunk_size) {
+        let processed_chunk: Vec<(Entry, MediaFile, Option<String>)> = chunk
+            .par_iter()
+            .map(|entry| {
+                let duration_secs = read_duration(&entry.path);
+                let size_bytes = read_size(&entry.path);
+                let hash = partial_hash(&entry.path);
 
-        let mut paths_to_remove: std::collections::HashSet<String> = std::collections::HashSet::new();
-        let duplicates: Vec<Vec<String>> = seen.into_values()
-            .filter(|paths| paths.len() > 1)
-            .map(|paths| {
-                for path in paths.iter().skip(1) {
-                    paths_to_remove.insert(path.clone());
-                }
-                paths
+                let file = MediaFile {
+                    path: entry.path.clone(),
+                    name: entry.name.clone(),
+                    ext: entry.ext.clone(),
+                    duration_secs,
+                    size_bytes,
+                };
+
+                // clone entry since we only have a borrowed reference
+                let entry_clone = Entry {
+                    path: entry.path.clone(),
+                    name: entry.name.clone(),
+                    ext: entry.ext.clone(),
+                    top: entry.top.clone(),
+                    album: entry.album.clone(),
+                };
+
+                (entry_clone, file, hash)
             })
             .collect();
 
-        println!("paths_to_remove: {:?}", paths_to_remove);
-        println!("sample file path: {}", directories[0].files.first().map(|f| f.path.as_str()).unwrap_or("none"));
+        // single-threaded merge into groups + dedup tracking
+        for (entry, file, hash) in processed_chunk {
+            if let Some(hash) = hash {
+                let paths = seen.entry(hash).or_insert_with(Vec::new);
+                if !paths.is_empty() {
+                    paths.push(file.path.clone());
+                    continue;
+                }
+                paths.push(file.path.clone());
+            }
 
-        // remove duplicates first
-        for dir in directories.iter_mut() {
-            dir.files.retain(|f| !paths_to_remove.contains(&f.path));
-            for album in dir.albums.iter_mut() {
-                album.files.retain(|f| !paths_to_remove.contains(&f.path));
+            let group = groups.entry(entry.top.clone()).or_insert(Directory {
+                name: entry.top.clone(),
+                path: home.join(&entry.top).to_string_lossy().to_string(),
+                albums: Vec::new(),
+                files: Vec::new(),
+            });
+
+            if let Some(album_name) = entry.album {
+                if let Some(alb) = group.albums.iter_mut().find(|a| a.name == album_name) {
+                    alb.files.push(file);
+                } else {
+                    group.albums.push(Album { name: album_name, files: vec![file] });
+                }
+            } else {
+                group.files.push(file);
             }
         }
 
-        // then count after dedup
-        let total_files = directories.iter()
+        // emit after each chunk
+        let mut current: Vec<&Directory> = groups.values().collect();
+        current.sort_by(|a, b| a.name.cmp(&b.name));
+        app.emit("scan_progress", &current).ok();
+
+        let count: usize = groups.values()
             .map(|d| d.files.len() + d.albums.iter().map(|a| a.files.len()).sum::<usize>())
             .sum();
-        let total_albums = directories.iter().map(|d| d.albums.len()).sum();
-        let total_directories = directories.len();
-        ScanResult {
-            metadata: ScanMetaData { duration_ms: start.elapsed().as_millis(), total_files, total_albums, total_directories, total_duplicates: duplicates.len() },
-            directories,
-            duplicates
+        println!("after chunk: count = {}", count);
+        app.emit("scan_count", count).ok();
+
+    }
+
+   let final_count: usize = groups.values()
+    .map(|d| d.files.len() + d.albums.iter().map(|a| a.files.len()).sum::<usize>())
+    .sum();
+println!("after all chunks, before retain: {}", final_count);
+
+    // post-processing — sort, dedup retain, build metadata
+    let mut directories: Vec<Directory> = groups.into_values().collect();
+    directories.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let mut paths_to_remove: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let duplicates: Vec<Vec<String>> = seen.into_values()
+        .filter(|paths| paths.len() > 1)
+        .map(|paths| {
+            for path in paths.iter().skip(1) {
+                paths_to_remove.insert(path.clone());
+            }
+            paths
+        })
+        .collect();
+
+    for dir in directories.iter_mut() {
+        dir.files.retain(|f| !paths_to_remove.contains(&f.path));
+        for album in dir.albums.iter_mut() {
+            album.files.retain(|f| !paths_to_remove.contains(&f.path));
         }
+    }
 
+    let total_files = directories.iter()
+        .map(|d| d.files.len() + d.albums.iter().map(|a| a.files.len()).sum::<usize>())
+        .sum();
+    let total_albums = directories.iter().map(|d| d.albums.len()).sum();
+    let total_directories = directories.len();
 
+    ScanResult {
+        metadata: ScanMetaData {
+            duration_ms: start.elapsed().as_millis(),
+            total_files,
+            total_albums,
+            total_directories,
+            total_duplicates: duplicates.len(),
+        },
+        directories,
+        duplicates,
+    }
 }
+      

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { PlayerBar } from "./components/PlayerBar";
 import { usePlayer } from "./hooks/usePlayer";
 import { filterDirs } from "./utils/filterDirs";
 import { useScan } from "./hooks/useScan";
+import { useDurations } from "./hooks/useDurations";
 
 function App() {
 
@@ -16,6 +17,7 @@ function App() {
     liveCount,
     scanState
   } = useScan();
+  const durations = useDurations(dirs);
 
   const filteredDirs = useMemo(() => filterDirs(dirs, query), [dirs, query])
 
@@ -37,7 +39,9 @@ function App() {
     liveCount={liveCount}
   />
   <Library
-  scanState={scanState}  currentTrack={currentTrack} dirs={filteredDirs} onPlay={play} query={query} />
+  scanState={scanState}
+  durations={durations}
+  currentTrack={currentTrack} dirs={filteredDirs} onPlay={play} query={query} />
   
   <PlayerBar 
     track={currentTrack}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,42 +1,25 @@
-import { useEffect, useMemo, useState } from "react";
-import { invoke } from "@tauri-apps/api/core";
-import {listen} from "@tauri-apps/api/event";
+import { useMemo, useState } from "react";
 import "./App.css";
-import { Directory, ScanMetaData, ScanResult, ScanState } from "./types";
 import { Header } from "./components/Header";
 import { Library } from "./components/Library";
 import { PlayerBar } from "./components/PlayerBar";
 import { usePlayer } from "./hooks/usePlayer";
 import { filterDirs } from "./utils/filterDirs";
+import { useScan } from "./hooks/useScan";
 
 function App() {
-  const [scanMeta, setScanMeta] = useState<ScanMetaData | null>(null);
-  const [dirs, setDirs] = useState<Directory[]>([]);
+
   const [query, setQuery] = useState('');
-  const [scanState, setScanState] = useState<ScanState>('idle');
+  const {
+    scanMeta,
+    dirs,
+    liveCount,
+    scanState
+  } = useScan();
 
   const filteredDirs = useMemo(() => filterDirs(dirs, query), [dirs, query])
 
-  useEffect(() => {
-    setScanState('scanning')
 
-    // mount listener
-    const unlisten = listen<Directory[]>('scan_progress', event => {
-      setDirs(event.payload)
-    })
-
-
-    invoke<ScanResult>("scan_media").then(r => {
-      setDirs(r.directories)
-      setScanMeta(r.metadata)
-      setScanState('done')
-    })  
-
-    // unmount listener on cleanup
-    return () => {
-      unlisten.then(f => f())
-    }
-  }, []);
 
   const {
     currentTrack,
@@ -51,6 +34,7 @@ function App() {
   scanState={scanState}
   onSearch={setQuery} 
     scanMeta={scanMeta}
+    liveCount={liveCount}
   />
   <Library
   scanState={scanState}  currentTrack={currentTrack} dirs={filteredDirs} onPlay={play} query={query} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,9 +5,10 @@ interface HeaderProps {
   onSearch: (q: string) => void
   scanMeta: ScanMetaData | null
   scanState: ScanState
+  liveCount?: number
 }
 
-export function Header({ query, onSearch, scanMeta, scanState }: HeaderProps) {
+export function Header({ query, onSearch, scanMeta, scanState, liveCount }: HeaderProps) {
   return (
     <div className="shrink-0 px-4 pt-4 pb-3 border-b border-slate-700">
       <span className="text-teal-400 font-bold tracking-wide text-sm">
@@ -18,7 +19,7 @@ export function Header({ query, onSearch, scanMeta, scanState }: HeaderProps) {
             <div className="flex items-center gap-2 mt-1">
               <div className="w-1.5 h-1.5 rounded-full bg-teal-400 animate-pulse" />
               <span className="text-xs text-slate-500 font-mono animate-pulse">
-                scanning library...
+                scanning library... {liveCount && <span className="text-app-text">{liveCount} files</span>}
               </span>
             </div>
         )}

--- a/src/components/Library.tsx
+++ b/src/components/Library.tsx
@@ -10,11 +10,12 @@ interface LibraryProps {
   currentTrack: MediaFile | null
   onPlay: (file: MediaFile) => void
   scanState: ScanState
+  durations: Record<string, number>
 }
 
 
 
-export function Library({ dirs, query, currentTrack, onPlay, scanState }: LibraryProps) {
+export function Library({ dirs, query, currentTrack, onPlay, scanState, durations }: LibraryProps) {
   const filtered = dirs
 
   const {isCollapsed, toggle} = useCollapsed()
@@ -55,6 +56,7 @@ export function Library({ dirs, query, currentTrack, onPlay, scanState }: Librar
             currentTrack={currentTrack}
             onPlay={onPlay}
             query={query}
+            durations={durations}
           />
 
           {dir.albums.map(album => {
@@ -85,6 +87,7 @@ export function Library({ dirs, query, currentTrack, onPlay, scanState }: Librar
                     currentTrack={currentTrack}
                     onPlay={onPlay}
                     query={query}
+                    durations={durations}
                   />
                 </div>
               </div>

--- a/src/components/Track.tsx
+++ b/src/components/Track.tsx
@@ -6,6 +6,7 @@ interface TrackProps {
   onPlay: (file: MediaFile) => void
   isPlaying?: boolean
   query: string
+  durations: Record<string, number>
 }
 
 const videoExts = ['mp4', 'mkv', 'webm', 'avi', 'mov']
@@ -37,7 +38,9 @@ function formatSize(bytes: number) {
   return `${(bytes / (1024 * 1024)).toFixed(1)}MB`
 }
 
-export function Track({ file, onPlay, isPlaying = false, query   }: TrackProps) {
+export function Track({ file, onPlay, isPlaying = false, query, durations }: TrackProps) {
+  const duration = durations[file.path] ?? 0;
+
   const displayName = file.name.replace(/\.[^/.]+$/, '') 
   const isVideo = videoExts.includes(file.ext.toLowerCase())
 
@@ -57,7 +60,7 @@ return (
     </span>
 
    <span className="text-xs font-mono text-slate-600 shrink-0 w-10 text-right">
-      {formatDuration(file.duration_secs)}
+      {formatDuration(duration)}
   </span>
   <span className="text-xs font-mono text-slate-600 shrink-0 w-16 text-right">
      {formatSize(file.size_bytes)}

--- a/src/components/TrackList.tsx
+++ b/src/components/TrackList.tsx
@@ -7,9 +7,10 @@ interface TrackListProps {
     query: string
     onPlay: (file: MediaFile) => void
 
+    durations: Record<string, number>
 }
 
-export function TrackList({ files, currentTrack, query, onPlay }: TrackListProps) {
+export function TrackList({ files, currentTrack, query, onPlay, durations }: TrackListProps) {
     if (files.length === 0) return null
 
    return (
@@ -20,6 +21,7 @@ export function TrackList({ files, currentTrack, query, onPlay }: TrackListProps
           file={file}
           query={query}
           onPlay={onPlay}
+          durations={durations}
           isPlaying={currentTrack?.path === file.path}
         />
       ))}

--- a/src/hooks/useDurations.ts
+++ b/src/hooks/useDurations.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef, useState } from "react";
+import { Directory } from "../types";
+import { convertFileSrc } from "@tauri-apps/api/core";
+
+
+function getDuration(path: string): Promise<number> {
+    return new Promise((resolve) => {
+        const audio = new Audio();
+        audio.src = convertFileSrc(path);
+        audio.onloadedmetadata = () => {
+            resolve(audio.duration || 0);
+            audio.src = "";
+        }
+        audio.onerror = () => {
+            resolve(0);
+        }
+    })
+}
+
+const CONCURRENT_LIMIT = 6;
+
+export function useDurations(dirs: Directory[]) {
+    const [durations, setDurations] = useState<Record<string, number>>({});
+
+    const queue = useRef<string[]>([]);
+
+    const inFlight = useRef(0);
+
+    useEffect(() => {
+        const allFiles = dirs.flatMap(d => [
+            ...d.files.map(f => f.path),
+            ...d.albums.flatMap(a => a.files.map(f => f.path))
+        ])
+        queue.current = allFiles.filter(path => !(path in durations));
+        pump();
+    }, [dirs])
+
+    function pump() {
+        while (inFlight.current < CONCURRENT_LIMIT && queue.current.length > 0) {
+            const path = queue.current.shift()!;
+            inFlight.current++;
+            getDuration(path).then(duration => {
+                setDurations(prev => ({ ...prev, [path]: duration }));
+                inFlight.current--;
+                pump();
+            })
+        }
+    }
+    return durations;
+
+}

--- a/src/hooks/useScan.ts
+++ b/src/hooks/useScan.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef, useState } from "react";
+import { ScanMetaData, Directory, ScanState, ScanResult } from "../types";
+import { listen } from "@tauri-apps/api/event";
+import { invoke } from "@tauri-apps/api/core";
+
+export function useScan() {
+    const [scanMeta, setScanMeta] = useState<ScanMetaData | null>(null);
+    const [dirs, setDirs] = useState<Directory[]>([]);
+    const [scanState, setScanState] = useState<ScanState>('idle');
+    const [liveCount, setLiveCount] = useState<number>(0);
+
+    const hasScanned = useRef(false)    
+
+      useEffect(() => {
+        if (hasScanned.current) return;
+        hasScanned.current = true;
+        setScanState('scanning')
+    
+        let unlistenProgress: () => void;
+        let unlistenCount: () => void;
+
+        async function setupListeners() {
+            unlistenProgress = await listen<Directory[]>("scan_progress", (event) => {
+                setDirs(event.payload);
+            })
+            unlistenCount = await listen<number>("scan_count", (event) => {
+                setLiveCount(event.payload);
+            })
+
+            const invokeResult = await invoke<ScanResult>("scan_media")
+            setScanMeta(invokeResult.metadata);
+            setDirs(invokeResult.directories);
+            setScanState('done')
+        }
+        setupListeners();
+
+        return () => {
+            unlistenProgress?.();
+            unlistenCount?.();
+        }
+      }, []);
+      return { scanMeta, dirs, scanState, liveCount };
+}


### PR DESCRIPTION
- Removed `lofty` from Rust — duration parsing was the main bottleneck during scans
- `MediaFile.duration_secs` now returns `0.0` from Rust and is filled in on the JS side
- Added `useDurations` hook that reads durations via browser `<audio>` element with 6 parallel reads
- Library now appears instantly with `--:--` placeholders that fill in within seconds
- Builds on top of chunked parallel scanning so progress events still stream during the walk