### PR TITLE
44 music spaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+binaries/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,206 @@
+# Architecture
+
+## Overview
+
+PlayMusic is a Tauri 2 desktop app with a React frontend and Rust backend.
+The app is structured around the concept of "spaces" — distinct music sources
+(local filesystem, online streaming, etc.) that share common playback
+infrastructure.
+
+## Tech Stack
+
+- **Frontend**: React 18 + TypeScript + Vite + Tailwind CSS v4
+- **Backend**: Rust (Tauri 2) for filesystem scanning, audio decoding, OS integration
+- **State**: Zustand for global state, no React Context
+- **Package manager**: Bun
+- **Targets**: Windows (primary), macOS, Linux
+
+## Top-Level Layout
+
+┌─────────────────────────────────────────────────┐
+│ Titlebar (custom — minimize/maximize/close) │
+├─────────────────────────────────────────────────┤
+│ Header (logo, scan stats, search bar) │
+├──────┬──────────────────────────────────────────┤
+│ │ │
+│Space │ Active Space Component │
+│Side │ (Local | Online | …) │
+│bar │ │
+│ ├─────────────┬────────────────────────────┤
+│ │ │ Video Pane (right side, │
+│ │ Library │ when video track playing) │
+│ │ │ │
+├──────┴─────────────┴────────────────────────────┤
+│ Player Bar (overlays bottom of content) │
+└─────────────────────────────────────────────────┘
+
+## Spaces
+
+A "space" is a self-contained content view registered in `src/spaces/index.tsx`.
+Each space defines:
+
+- `id` — unique identifier
+- `name` — display name
+- `icon` — JSX element for the sidebar
+- `Component` — the React component rendered when the space is active
+
+Switching spaces does NOT pause playback. The player bar, video pane, audio
+volume, and current track persist across space switches because they live at
+the root level, not inside any space.
+
+### Active Spaces
+
+| Space  | Source                   | Status         |
+| ------ | ------------------------ | -------------- |
+| Local  | Filesystem scan via Rust | ✅ Implemented |
+| Online | yt-dlp search/streaming  | 🚧 Placeholder |
+
+### Adding a New Space
+
+1. Create `src/spaces/MySpace.tsx` with a default export component
+2. Add it to `SPACES` array in `src/spaces/index.tsx`
+3. Add per-space state to `spaces` object in `src/store.ts` if needed
+4. Sidebar icon appears automatically
+
+## State Architecture (Zustand)
+
+Single store at `src/store.ts`. Three categories of state:
+
+### Root-level (shared across spaces)
+
+- `activeSpaceId` — currently selected space
+- `currentTrack` — the playing track (regardless of source)
+- `playing` — playback state (true/false)
+- `theme` — `'dark' | 'light'`
+
+### Per-space (namespaced under `spaces.{id}`)
+
+- `spaces.local.dirs` — scanned directory tree
+- `spaces.local.scanMeta` — scan timing/counts
+- `spaces.local.scanState` — `'idle' | 'scanning' | 'done'`
+- `spaces.local.liveCount` — live file count during scan
+- `spaces.local.query` — search input
+- `spaces.local.durations` — `Record<path, seconds>` filled lazily
+- `spaces.local.collapsed` — `Set<string>` of collapsed album keys
+
+### Selective subscriptions
+
+Components only re-render when the slice they subscribe to changes:
+
+```tsx
+const dirs = useAppStore((s) => s.spaces.local.dirs)
+```
+
+## Component Hierarchy
+
+App.tsx
+├── Titlebar
+├── Header
+├── (main row)
+│ ├── SpaceSidebar
+│ ├── <ActiveSpace /> ← LocalSpace, OnlineSpace, etc.
+│ │ └── (Local) Library
+│ │ └── TrackList
+│ │ └── Track (×N)
+│ │ └── PlayingIndicator (when active)
+│ ├── ScrollToActive ← lives inside LocalSpace
+│ └── VideoPane ← portal target for video element
+└── PlayerBar (absolute bottom, overlay)
+├── Waveform
+└── createPortal(<video>) → VideoPane
+
+## Rust Backend (`src-tauri/src/`)
+
+lib.rs ← entry, registers commands, runs Tauri
+scanner.rs ← scan_media command, walks filesystem with rayon
+waveform.rs ← generate_waveform command, decodes via symphonia
+
+### Tauri Commands
+
+| Command             | Purpose                                    | Sync/Async |
+| ------------------- | ------------------------------------------ | ---------- |
+| `scan_media`        | Recursive scan, emits progress events      | async      |
+| `generate_waveform` | Decode + downsample first 60s for waveform | sync       |
+
+### Scan Pipeline (3-phase, parallelized)
+
+1. **Walk** (single-threaded) — `WalkDir` collects valid media file entries
+2. **Process** (parallel via `rayon`) — chunked metadata reading + partial hash
+3. **Merge** (single-threaded) — build directory tree, dedup, emit progress
+
+Progress is emitted between chunks via `app.emit('scan_progress', dirs)` and
+`app.emit('scan_count', count)`.
+
+### Album Art Caching
+
+- Extracted via `lofty` from audio file tags
+- Cached to OS app cache dir: `app_cache_dir/art_{hash}.jpg`
+- File path returned to frontend, rendered via `convertFileSrc`
+
+### Waveform Generation
+
+- Reads first 60 seconds of audio frames using `symphonia`
+- Bounded memory regardless of file size — fixes WebView crashes on large files
+- Downsampled to 100 normalized `f32` values
+- Returned to frontend as `{ samples: number[] }`
+
+## Custom Hooks (`src/hooks/`)
+
+| Hook             | Purpose                                                      |
+| ---------------- | ------------------------------------------------------------ |
+| `useScan`        | Mounts scan listeners, invokes `scan_media`, writes to store |
+| `useDurations`   | Lazily fills track durations via `<audio>` metadata          |
+| `useMediaPlayer` | Audio/video playback controls, time, volume                  |
+| `useVolume`      | Volume state with localStorage persistence + mute toggle     |
+| `useWaveform`    | Invokes Rust `generate_waveform`, manages loading state      |
+| `useResizable`   | Generic horizontal/vertical drag-to-resize with persistence  |
+| `useFullscreen`  | Browser fullscreen API wrapper                               |
+| `usePlayer`      | Next/prev track navigation across the flat track list        |
+
+## Theming
+
+Two themes via CSS variables in `src/App.css` `@theme` block:
+
+- Default `:root` — dark mode (twilight blue gradient + amber accent)
+- `[data-theme="light"]` — Mirror's Edge inspired (white + crimson red)
+
+Theme toggled via `useAppStore(s => s.setTheme)`. Setting persists to
+localStorage and applies via `document.documentElement.dataset.theme`.
+
+Background gradients on `body` provide visual depth that's preserved by
+translucent panel surfaces (`bg-app-bg/80`).
+
+## Window Vibrancy (Windows)
+
+- `tauri.conf.json` — `transparent: true, decorations: false`
+- `lib.rs` — applies Mica (Win11) / Acrylic (Win10) via `window-vibrancy` crate
+- `body` background uses linear gradient, panels use translucent backgrounds
+
+## Persistence
+
+Stored in localStorage:
+
+- `playmusic-theme` — current theme
+- `playmusic-volume` — last volume setting
+- `playmusic-collapsed` — Set of collapsed album keys
+- `playmusic-playerbar-height` — last drag-resized player bar height
+- `playmusic-videopane-width` — last drag-resized video pane width
+
+Album art cache stored in OS app cache dir (cleared if the app is uninstalled).
+
+## Constants & Utilities
+
+- `src/constants.ts` — `VIDEO_EXTS`, `AUDIO_EXTS`, `isVideo()`, `isAudio()`
+- `src/utils/filterDirs.ts` — fuzzy search via Fuse.js with weighted fields
+
+## Conventions
+
+- Colors in components use `text-app-*`, `bg-app-*`, `border-app-*` classes
+  or `var(--color-app-*)` in inline styles. No hardcoded hex values or raw
+  `slate-*` / `red-*` Tailwind classes.
+- New shared state goes in the Zustand store, not React Context.
+- Local-space-specific state lives under `spaces.local.*` in the store.
+- Components subscribe selectively via `useAppStore(s => s.specificField)` to
+  minimize re-renders.
+- Heavy CPU/IO work runs in Rust commands, not in the WebView.
+- Long-running operations emit progress events for streaming UI updates.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2478,6 +2478,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2773,6 +2783,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "tauri-plugin-shell",
  "walkdir",
 ]
 
@@ -3501,10 +3512,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_child"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
+dependencies = [
+ "libc",
+ "sigchld",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "sigchld"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
+dependencies = [
+ "libc",
+ "os_pipe",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -4110,6 +4153,27 @@ dependencies = [
  "url",
  "windows",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-shell"
+version = "2.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8457dbf9e2bab1edd8df22bb2c20857a59a9868e79cb3eac5ed639eec4d0c73b"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "open",
+ "os_pipe",
+ "regex",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "shared_child",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,3 +28,4 @@ md5 = "0.7"
 symphonia = { version = "0.5", features = ["mp3", "aac", "flac", "ogg", "wav", "isomp4"] }
 rayon = "1"
 lofty = "0.21"
+tauri-plugin-shell = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -9,6 +9,16 @@
     "core:window:allow-maximize",
     "core:window:allow-toggle-maximize",
     "core:window:allow-close",
-    "core:window:allow-start-dragging"
+    "core:window:allow-start-dragging",
+    {
+      "identifier": "shell:allow-execute",
+      "allow": [
+        {
+          "name": "binaries/yt-dlp",
+          "sidecar": true,
+          "args": true
+        }
+      ]
+    }
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,14 +1,18 @@
 mod scanner;
 mod waveform;
-
-
-
+mod online;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![scanner::scan_media, waveform::generate_waveform])
+        .plugin(tauri_plugin_shell::init())
+        .invoke_handler(tauri::generate_handler![
+            scanner::scan_media,
+            waveform::generate_waveform,
+            online::search_online,
+            online::resolve_stream,
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/online.rs
+++ b/src-tauri/src/online.rs
@@ -1,0 +1,128 @@
+use serde::{Deserialize, Serialize};
+use tauri_plugin_shell::ShellExt;
+
+#[derive(Debug, Serialize)]
+pub struct OnlineSearchResult {
+    pub video_id: String,
+    pub title: String,
+    pub duration_secs: f64,
+    pub thumbnail: Option<String>,
+    pub uploader: Option<String>,
+}
+
+// What yt-dlp emits per line with --dump-json --flat-playlist
+#[derive(Debug, Deserialize)]
+struct YtDlpFlatEntry {
+    id: String,
+    title: String,
+    duration: Option<f64>,
+    thumbnails: Option<Vec<YtDlpThumbnail>>,
+    uploader: Option<String>,
+    channel: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct YtDlpThumbnail {
+    url: String,
+    width: Option<u32>,
+}
+
+#[tauri::command]
+pub async fn search_online(
+    app: tauri::AppHandle,
+    query: String,
+) -> Result<Vec<OnlineSearchResult>, String> {
+    if query.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let search_arg = format!("ytsearch10:{}", query);
+
+    let output = app
+        .shell()
+        .sidecar("yt-dlp")
+        .map_err(|e| format!("failed to create sidecar: {e}"))?
+        .args([
+            "--dump-json",
+            "--flat-playlist",
+            "--no-warnings",
+            "--no-playlist",
+            &search_arg,
+        ])
+        .output()
+        .await
+        .map_err(|e| format!("yt-dlp execution failed: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("yt-dlp exited with error: {stderr}"));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let results = stdout
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(|line| serde_json::from_str::<YtDlpFlatEntry>(line).ok())
+        .map(|entry| OnlineSearchResult {
+            video_id: entry.id,
+            title: entry.title,
+            duration_secs: entry.duration.unwrap_or(0.0),
+            thumbnail: pick_thumbnail(entry.thumbnails),
+            uploader: entry.uploader.or(entry.channel),
+        })
+        .collect();
+
+    Ok(results)
+}
+
+#[tauri::command]
+pub async fn resolve_stream(
+    app: tauri::AppHandle,
+    video_id: String,
+) -> Result<String, String> {
+    let url = format!("https://www.youtube.com/watch?v={video_id}");
+
+    let output = app
+        .shell()
+        .sidecar("yt-dlp")
+        .map_err(|e| format!("failed to create sidecar: {e}"))?
+        .args([
+            "-f",
+            "bestaudio",
+            "--get-url",
+            "--no-warnings",
+            "--no-playlist",
+            &url,
+        ])
+        .output()
+        .await
+        .map_err(|e| format!("yt-dlp execution failed: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("yt-dlp exited with error: {stderr}"));
+    }
+
+    let stream_url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+    if stream_url.is_empty() {
+        return Err("yt-dlp returned empty stream URL".to_string());
+    }
+
+    Ok(stream_url)
+}
+
+/// Pick a reasonable thumbnail — prefer medium-sized ones, fall back to first or none.
+fn pick_thumbnail(thumbnails: Option<Vec<YtDlpThumbnail>>) -> Option<String> {
+    let mut thumbs = thumbnails?;
+    if thumbs.is_empty() {
+        return None;
+    }
+    // Sort: thumbnails with known width come first, ordered by closeness to ~320px.
+    // Falls back to first thumbnail if none have widths.
+    thumbs.sort_by_key(|t| match t.width {
+        Some(w) => (0u8, (w as i32 - 320).abs()),
+        None => (1u8, 0),
+    });
+    thumbs.into_iter().next().map(|t| t.url)
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -39,6 +39,7 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "externalBin": ["binaries/yt-dlp"]
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,28 @@
 import './App.css'
 import { Header } from './components/Header'
-import { Library } from './components/Library'
 import { PlayerBar } from './components/PlayerBar'
 import { useScan } from './hooks/useScan'
 import { useDurations } from './hooks/useDurations'
 import { VideoPane } from './components/VideoPane'
 import { Titlebar } from './components/TitleBar'
+import { useAppStore } from './store'
+import { SPACES } from './spaces'
+import { SpaceSidebar } from './components/SpaceSidebar'
 
 function App() {
+  const activeSpaceId = useAppStore((s) => s.activeSpaceId)
+  const ActiveSpace = SPACES.find((s) => s.id === activeSpaceId)?.Component ?? (() => null)
+
   useScan()
   useDurations()
 
   return (
-    <div className="h-screen font-mono flex flex-col overflow-hidden">
+    <div className="h-screen font-mono flex flex-col overflow-hidden relative">
       <Titlebar />
       <Header />
       <div className="flex-1 flex overflow-hidden">
-        <Library />
-
+        <SpaceSidebar />
+        <ActiveSpace />
         <VideoPane />
       </div>
       <PlayerBar />

--- a/src/api/local.ts
+++ b/src/api/local.ts
@@ -1,0 +1,5 @@
+import { MediaFile, LocalTrack } from '../types'
+
+export function localTrack(file: MediaFile): LocalTrack {
+  return { ...file, source: 'local' }
+}

--- a/src/api/online.ts
+++ b/src/api/online.ts
@@ -1,0 +1,33 @@
+// src/api/online.ts
+import { invoke } from '@tauri-apps/api/core'
+import { OnlineSearchResult, OnlineTrack } from '../types'
+
+export async function searchOnline(query: string): Promise<OnlineSearchResult[]> {
+  const trimmed = query.trim()
+  if (!trimmed) return []
+  return invoke<OnlineSearchResult[]>('search_online', { query: trimmed })
+}
+
+export async function resolveStream(videoId: string): Promise<string> {
+  return invoke<string>('resolve_stream', { videoId })
+}
+
+/**
+ * Convert a yt-dlp search result into a Track that can be played.
+ * The actual stream URL is resolved lazily inside useMediaPlayer
+ * (yt-dlp URLs expire, so we don't store them).
+ */
+export function resultToTrack(result: OnlineSearchResult): OnlineTrack {
+  return {
+    source: 'online',
+    videoId: result.video_id,
+    path: result.video_id, // used as stable id by existing UI
+    name: result.title,
+    ext: 'webm', // bestaudio default; not used for routing
+    duration_secs: result.duration_secs,
+    size_bytes: 0,
+    art_path: result.thumbnail, // already an https URL
+    created_at: Date.now(),
+    uploader: result.uploader ?? undefined,
+  }
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,68 +1,19 @@
-import { Search } from 'lucide-react'
 import { useAppStore } from '../store'
+import { SPACES } from '../spaces'
 import { ThemeToggle } from './ThemeToggle'
 
 export function Header() {
-  const query = useAppStore((s) => s.spaces.local.query)
-  const setQuery = useAppStore((s) => s.setLocalQuery)
-  const scanMeta = useAppStore((s) => s.spaces.local.scanMeta)
-  const scanState = useAppStore((s) => s.spaces.local.scanState)
-  const liveCount = useAppStore((s) => s.spaces.local.liveCount)
+  const activeSpaceId = useAppStore((s) => s.activeSpaceId)
+  const space = SPACES.find((s) => s.id === activeSpaceId)
+  const SpaceHeader = space?.Header
 
   return (
     <div className="shrink-0 px-6 pt-5 pb-4 border-b border-app-border">
-      {/* top row — logo + stats */}
-      <div className="flex items-center gap-4 mb-4">
-        {scanMeta && (
-          <div className="flex items-center gap-3 text-xs font-mono text-app-muted">
-            <span className="text-app-text">{scanMeta.total_files}</span>
-            <span>files</span>
-            <span className="text-app-muted">·</span>
-            <span className="text-app-text">{scanMeta.total_albums}</span>
-            <span>albums</span>
-            <span className="text-app-muted">·</span>
-            <span className="text-app-text">{scanMeta.total_directories}</span>
-            <span>dirs</span>
-            <span className="text-app-muted">·</span>
-            <span className="text-app-text">{scanMeta.duration_ms}ms</span>
-            {scanMeta.total_duplicates > 0 && (
-              <>
-                <span className="text-app-muted">·</span>
-                <span className="text-app-accent font-bold">
-                  {scanMeta.total_duplicates} duplicates
-                </span>
-              </>
-            )}
-          </div>
-        )}
-
-        {scanState === 'scanning' && (
-          <div className="flex items-center gap-2">
-            <div className="w-1.5 h-1.5 rounded-full bg-app-accent animate-pulse" />
-            <span className="text-xs text-app-muted font-mono">
-              scanning... {liveCount > 0 && `${liveCount} files`}
-            </span>
-          </div>
-        )}
-        <div className="ml-auto">
+      <div className="flex items-start gap-4">
+        <div className="flex-1 min-w-0">{SpaceHeader && <SpaceHeader />}</div>
+        <div className="shrink-0 pt-0.5">
           <ThemeToggle />
         </div>
-      </div>
-
-      {/* search bar row */}
-      <div className="flex items-center gap-3 px-3 py-2 rounded border border-app-border hover:border-app-accent-dim transition-colors focus-within:border-app-accent">
-        <Search size={16} className="text-app-muted shrink-0" />
-        <input
-          type="text"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder="type to search..."
-          className="bg-transparent text-app-text text-sm font-mono placeholder-app-muted outline-none flex-1"
-        />
-        <span className="text-xs font-mono text-app-muted shrink-0 hidden md:inline">
-          try <span className="text-app-secondary">shadow</span> or{' '}
-          <span className="text-app-secondary">drumcode</span>
-        </span>
       </div>
     </div>
   )

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,11 +3,11 @@ import { useAppStore } from '../store'
 import { ThemeToggle } from './ThemeToggle'
 
 export function Header() {
-  const query = useAppStore((s) => s.query)
-  const setQuery = useAppStore((s) => s.setQuery)
-  const scanMeta = useAppStore((s) => s.scanMeta)
-  const scanState = useAppStore((s) => s.scanState)
-  const liveCount = useAppStore((s) => s.liveCount)
+  const query = useAppStore((s) => s.spaces.local.query)
+  const setQuery = useAppStore((s) => s.setLocalQuery)
+  const scanMeta = useAppStore((s) => s.spaces.local.scanMeta)
+  const scanState = useAppStore((s) => s.spaces.local.scanState)
+  const liveCount = useAppStore((s) => s.spaces.local.liveCount)
 
   return (
     <div className="shrink-0 px-6 pt-5 pb-4 border-b border-app-border">

--- a/src/components/Library.tsx
+++ b/src/components/Library.tsx
@@ -4,14 +4,13 @@ import { TrackList } from './TrackList'
 import { useAppStore } from '../store'
 import { useMemo } from 'react'
 import { filterDirs } from '../utils/filterDirs'
-import { ScrollToActive } from './ScrollToActivate'
 
 export function Library() {
-  const dirs = useAppStore((s) => s.dirs)
-  const query = useAppStore((s) => s.query)
-  const scanState = useAppStore((s) => s.scanState)
-  const collapsed = useAppStore((s) => s.collapsed)
-  const toggleCollapsed = useAppStore((s) => s.toggleCollapsed)
+  const dirs = useAppStore((s) => s.spaces.local.dirs)
+  const query = useAppStore((s) => s.spaces.local.query)
+  const scanState = useAppStore((s) => s.spaces.local.scanState)
+  const collapsed = useAppStore((s) => s.spaces.local.collapsed)
+  const toggleCollapsed = useAppStore((s) => s.toggleLocalCollapsed)
 
   const filtered = useMemo(() => filterDirs(dirs, query), [dirs, query])
 
@@ -26,61 +25,56 @@ export function Library() {
   }
 
   return (
-    <div className="flex-1 relative overflow-hidden">
-      <ScrollToActive />
-      <div className="overflow-y-auto h-full py-2">
-        {scanState === 'scanning' && (
-          <div className="px-4 py-1 text-xs text-slate-600 font-mono animate-pulse">
-            scanning...
-          </div>
-        )}
+    <div className="overflow-y-auto h-full py-2">
+      {scanState === 'scanning' && (
+        <div className="px-4 py-1 text-xs text-slate-600 font-mono animate-pulse">scanning...</div>
+      )}
 
-        {filtered.length === 0 && scanState === 'done' && (
-          <div className="px-4 py-3 text-xs text-slate-600 font-mono">
-            {query ? 'no results.' : 'no media found.'}
-          </div>
-        )}
+      {filtered.length === 0 && scanState === 'done' && (
+        <div className="px-4 py-3 text-xs text-slate-600 font-mono">
+          {query ? 'no results.' : 'no media found.'}
+        </div>
+      )}
 
-        {filtered.map((dir) => (
-          <div key={dir.path} className="mb-2">
-            <SectionHeader
-              name={dir.name}
-              count={dir.files.length + dir.albums.reduce((sum, a) => sum + a.files.length, 0)}
-            />
+      {filtered.map((dir) => (
+        <div key={dir.path} className="mb-2">
+          <SectionHeader
+            name={dir.name}
+            count={dir.files.length + dir.albums.reduce((sum, a) => sum + a.files.length, 0)}
+          />
 
-            <TrackList files={dir.files} />
+          <TrackList files={dir.files} />
 
-            {dir.albums.map((album) => {
-              const key = `${dir.name}/${album.name}`
-              const isAlbumCollapsed = collapsed.has(key)
+          {dir.albums.map((album) => {
+            const key = `${dir.name}/${album.name}`
+            const isAlbumCollapsed = collapsed.has(key)
 
-              return (
-                <div key={album.name}>
-                  <div
-                    onClick={() => toggleCollapsed(key)}
-                    className={`flex items-center gap-3 px-6 mt-3 cursor-pointer transition-colors py-1 ${
-                      isAlbumCollapsed ? 'bg-app-hover' : 'hover:bg-app-hover'
-                    }`}
-                  >
-                    <div className="text-app-muted">
-                      {isAlbumCollapsed ? <ChevronRight size={12} /> : <ChevronDown size={12} />}
-                    </div>
-                    <span className="text-xs font-mono text-app-secondary tracking-wide shrink-0">
-                      {album.name}
-                    </span>
-                    <div className="flex-1 h-px bg-app-border" />
-                    <span className="text-xs font-mono text-app-muted tabular-nums shrink-0">
-                      {album.files.length}
-                    </span>
+            return (
+              <div key={album.name}>
+                <div
+                  onClick={() => toggleCollapsed(key)}
+                  className={`flex items-center gap-3 px-6 mt-3 cursor-pointer transition-colors py-1 ${
+                    isAlbumCollapsed ? 'bg-app-hover' : 'hover:bg-app-hover'
+                  }`}
+                >
+                  <div className="text-app-muted">
+                    {isAlbumCollapsed ? <ChevronRight size={12} /> : <ChevronDown size={12} />}
                   </div>
-
-                  {!isAlbumCollapsed && <TrackList files={album.files} />}
+                  <span className="text-xs font-mono text-app-secondary tracking-wide shrink-0">
+                    {album.name}
+                  </span>
+                  <div className="flex-1 h-px bg-app-border" />
+                  <span className="text-xs font-mono text-app-muted tabular-nums shrink-0">
+                    {album.files.length}
+                  </span>
                 </div>
-              )
-            })}
-          </div>
-        ))}
-      </div>
+
+                {!isAlbumCollapsed && <TrackList files={album.files} />}
+              </div>
+            )
+          })}
+        </div>
+      ))}
     </div>
   )
 }

--- a/src/components/PlayerBar.tsx
+++ b/src/components/PlayerBar.tsx
@@ -1,13 +1,22 @@
 import { useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
-import { Play, Pause, SkipBack, SkipForward, Volume2, VolumeX, Maximize } from 'lucide-react'
+import {
+  Play,
+  Pause,
+  SkipBack,
+  SkipForward,
+  Volume2,
+  VolumeX,
+  Maximize,
+  Loader2,
+} from 'lucide-react'
 import { useAudioPlayer } from '../hooks/useAudioPlayer'
 import { useWaveform } from '../hooks/useWaveform'
 import { useResizable } from '../hooks/useResizable'
 import { Waveform } from './Waveform'
 import { isVideo } from '../constants'
 import { usePlayer } from '../hooks/usePlayer'
-import { useAppStore } from '../store'
+import { selectCurrentTrack, useAppStore } from '../store'
 import { useFullscreen } from '../hooks/useFullscreen'
 
 const MIN_HEIGHT = 160
@@ -19,7 +28,8 @@ function formatTime(s: number) {
 }
 
 export function PlayerBar() {
-  const track = useAppStore((s) => s.currentTrack)
+  const track = useAppStore(selectCurrentTrack)
+  const resolving = useAppStore((s) => s.resolving)
   const { next, prev } = usePlayer()
   const { size: height, startDrag } = useResizable({
     defaultSize: MIN_HEIGHT,
@@ -38,8 +48,8 @@ export function PlayerBar() {
   const trackIsVideo = track ? isVideo(track.ext) : false
 
   useEffect(() => {
-    if (!track) return
-    generateWaveform(track.path)
+    const path = track?.source === 'local' ? track.path : null
+    generateWaveform(path)
   }, [track])
 
   return (
@@ -86,9 +96,10 @@ export function PlayerBar() {
 
             <button
               onClick={toggle}
+              disabled={resolving}
               className="w-10 h-10 rounded-full bg-app-accent text-app-bg flex items-center justify-center hover:scale-105 transition-transform"
             >
-              {playing ? <Pause size={18} /> : <Play size={18} className="ml-0.5" />}
+              {resolving ? <Loader2 className="animate-spin" /> : playing ? <Pause /> : <Play />}
             </button>
 
             <button

--- a/src/components/ScrollToActivate.tsx
+++ b/src/components/ScrollToActivate.tsx
@@ -4,9 +4,9 @@ import { useAppStore } from '../store'
 
 export function ScrollToActive() {
   const currentTrack = useAppStore((s) => s.currentTrack)
-  const dirs = useAppStore((s) => s.dirs)
-  const collapsed = useAppStore((s) => s.collapsed)
-  const toggleCollapsed = useAppStore((s) => s.toggleCollapsed)
+  const dirs = useAppStore((s) => s.spaces.local.dirs)
+  const collapsed = useAppStore((s) => s.spaces.local.collapsed)
+  const toggleCollapsed = useAppStore((s) => s.toggleLocalCollapsed)
 
   const [offscreen, setOffscreen] = useState(false)
   const observer = useRef<IntersectionObserver | null>(null)

--- a/src/components/ScrollToActivate.tsx
+++ b/src/components/ScrollToActivate.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState, useRef } from 'react'
 import { Music } from 'lucide-react'
-import { useAppStore } from '../store'
+import { selectCurrentTrack, useAppStore } from '../store'
 
 export function ScrollToActive() {
-  const currentTrack = useAppStore((s) => s.currentTrack)
+  const currentTrack = useAppStore(selectCurrentTrack)
   const dirs = useAppStore((s) => s.spaces.local.dirs)
   const collapsed = useAppStore((s) => s.spaces.local.collapsed)
   const toggleCollapsed = useAppStore((s) => s.toggleLocalCollapsed)

--- a/src/components/SpaceSidebar.tsx
+++ b/src/components/SpaceSidebar.tsx
@@ -1,0 +1,29 @@
+import { SPACES } from '../spaces'
+import { useAppStore } from '../store'
+
+export function SpaceSidebar() {
+  const activeSpaceId = useAppStore((s) => s.activeSpaceId)
+  const setActiveSpaceId = useAppStore((s) => s.setActiveSpaceId)
+
+  return (
+    <div className="w-14 shrink-0 flex flex-col items-center gap-2 py-3 border-r border-app-border">
+      {SPACES.map((space) => {
+        const isActive = activeSpaceId === space.id
+        return (
+          <button
+            key={space.id}
+            onClick={() => setActiveSpaceId(space.id)}
+            title={space.name}
+            className={`w-10 h-10 rounded-lg flex items-center justify-center transition-colors ${
+              isActive
+                ? 'bg-app-accent text-app-accent-text'
+                : 'text-app-secondary hover:bg-app-hover hover:text-app-text'
+            }`}
+          >
+            {space.icon}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/Track.tsx
+++ b/src/components/Track.tsx
@@ -2,7 +2,9 @@ import { Music, Video } from 'lucide-react'
 import { MediaFile } from '../types'
 import { isVideo } from '../constants'
 import { PlayingIndicator } from './PlayingIndicator'
-import { useAppStore } from '../store'
+import { selectCurrentTrack, useAppStore } from '../store'
+import { localTrack } from '../api/local'
+import { useLocalFlatTracks } from '../hooks/useLocalFlatTracks'
 
 interface TrackProps {
   file: MediaFile
@@ -52,8 +54,11 @@ function formatRelative(ms: number): string {
 }
 
 export function Track({ file, index }: TrackProps) {
-  const currentTrack = useAppStore((s) => s.currentTrack)
-  const setCurrentTrack = useAppStore((s) => s.setCurrentTrack)
+  const currentTrack = useAppStore(selectCurrentTrack)
+
+  const flatTracks = useLocalFlatTracks()
+  const playTrackFromlist = useAppStore((s) => s.playTrackFromList)
+
   const playing = useAppStore((s) => s.playing)
   const query = useAppStore((s) => s.spaces.local.query)
   const duration = useAppStore((s) => s.spaces.local.durations[file.path] ?? 0)
@@ -64,10 +69,16 @@ export function Track({ file, index }: TrackProps) {
   const isVideoFile = isVideo(file.ext)
   const displayName = file.name.replace(/\.[^/.]+$/, '')
 
+  function handleClick() {
+    const idx = flatTracks.findIndex((t) => t.path === file.path)
+    if (idx < 0) return
+    playTrackFromlist(flatTracks, idx)
+  }
+
   return (
     <div
       data-track-path={file.path}
-      onClick={() => setCurrentTrack(file)}
+      onClick={handleClick}
       className={`group flex items-center gap-4 px-6 py-2 cursor-pointer transition-colors ${
         isActive ? 'bg-app-selected' : 'hover:bg-app-hover'
       }`}

--- a/src/components/Track.tsx
+++ b/src/components/Track.tsx
@@ -55,8 +55,8 @@ export function Track({ file, index }: TrackProps) {
   const currentTrack = useAppStore((s) => s.currentTrack)
   const setCurrentTrack = useAppStore((s) => s.setCurrentTrack)
   const playing = useAppStore((s) => s.playing)
-  const query = useAppStore((s) => s.query)
-  const duration = useAppStore((s) => s.durations[file.path] ?? 0)
+  const query = useAppStore((s) => s.spaces.local.query)
+  const duration = useAppStore((s) => s.spaces.local.durations[file.path] ?? 0)
 
   const isActive = currentTrack?.path == file.path
   const isCurrentlyPlaying = isActive && playing

--- a/src/components/Track.tsx
+++ b/src/components/Track.tsx
@@ -3,7 +3,6 @@ import { MediaFile } from '../types'
 import { isVideo } from '../constants'
 import { PlayingIndicator } from './PlayingIndicator'
 import { selectCurrentTrack, useAppStore } from '../store'
-import { localTrack } from '../api/local'
 import { useLocalFlatTracks } from '../hooks/useLocalFlatTracks'
 
 interface TrackProps {

--- a/src/components/VideoPane.tsx
+++ b/src/components/VideoPane.tsx
@@ -1,9 +1,9 @@
 import { isVideo } from '../constants'
 import { useResizable } from '../hooks/useResizable'
-import { useAppStore } from '../store'
+import { selectCurrentTrack, useAppStore } from '../store'
 
 export function VideoPane() {
-  const currentTrack = useAppStore((s) => s.currentTrack)
+  const currentTrack = useAppStore(selectCurrentTrack)
   const visible = !!(currentTrack && isVideo(currentTrack.ext))
 
   const { size: width, startDrag } = useResizable({

--- a/src/hooks/useAudioPlayer.ts
+++ b/src/hooks/useAudioPlayer.ts
@@ -2,14 +2,18 @@ import { useState, useEffect, useRef } from 'react'
 import { convertFileSrc } from '@tauri-apps/api/core'
 import { useVolume } from './useVolume'
 import { isVideo } from '../constants'
-import { useAppStore } from '../store'
+import { useAppStore, selectCurrentTrack } from '../store'
+import { resolveStream } from '../api/online'
+
+const RETRY_COOLDOWN_MS = 10_000
 
 export function useAudioPlayer(
   videoRef: React.RefObject<HTMLVideoElement | null>,
   onEnded?: () => void
 ) {
-  const track = useAppStore((s) => s.currentTrack)
+  const track = useAppStore(selectCurrentTrack)
   const setStorePlaying = useAppStore((s) => s.setPlaying)
+  const setResolving = useAppStore((s) => s.setResolving)
 
   const audioRef = useRef<HTMLAudioElement>(new Audio())
   const [playing, setPlaying] = useState(false)
@@ -17,9 +21,9 @@ export function useAudioPlayer(
   const [currentTime, setCurrentTime] = useState(0)
   const [convertedSrc, setConvertedSrc] = useState<string>('')
 
-  const { volume, changeVolume, toggleMute } = useVolume()
+  const lastRetryAt = useRef<number>(0)
 
-  //useAudioNormalization(audioRef)
+  const { volume, changeVolume, toggleMute } = useVolume()
 
   const trackIsVideo = track ? isVideo(track.ext) : false
 
@@ -35,26 +39,99 @@ export function useAudioPlayer(
   useEffect(() => {
     if (!track) return
 
-    // pause both elements before switching
     audioRef.current.pause()
     if (videoRef.current) videoRef.current.pause()
 
-    const src = convertFileSrc(track.path)
-    setConvertedSrc(src)
-    const media = getMedia()
-    media.src = src
-    media.load()
     setCurrentTime(0)
     setDuration(0)
     setPlaying(false)
+    setResolving(false)
+    lastRetryAt.current = 0 // reset cooldown when track changes
 
-    const playPromise = media.play()
-    if (playPromise) {
-      playPromise
-        .then(() => setPlaying(true))
-        .catch((e) => {
-          if (e.name !== 'AbortError') console.error(e)
-        })
+    let cancelled = false
+
+    ;(async () => {
+      let src: string
+      if (track.source === 'local') {
+        src = convertFileSrc(track.path)
+      } else {
+        setResolving(true)
+        try {
+          src = await resolveStream(track.videoId)
+        } catch (e) {
+          console.error('failed to resolve stream:', e)
+          if (!cancelled) setResolving(false)
+          return
+        }
+        if (cancelled) return
+        setResolving(false)
+      }
+
+      if (cancelled) return
+
+      setConvertedSrc(src)
+      const media = getMedia()
+      media.src = src
+      media.load()
+
+      const playPromise = media.play()
+      if (playPromise) {
+        playPromise
+          .then(() => {
+            if (!cancelled) setPlaying(true)
+          })
+          .catch((e) => {
+            if (e.name !== 'AbortError') console.error(e)
+          })
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [track])
+
+  // retry on stream URL expiry for online tracks
+  useEffect(() => {
+    if (!track || track.source !== 'online') return
+    const videoId = track.videoId
+    const media = getMedia()
+
+    let cancelled = false
+
+    async function handleError() {
+      const now = Date.now()
+      if (now - lastRetryAt.current < RETRY_COOLDOWN_MS) return
+      lastRetryAt.current = now
+
+      const resumeAt = media.currentTime
+      const wasPlaying = !media.paused
+
+      setResolving(true)
+
+      try {
+        const fresh = await resolveStream(videoId)
+        if (cancelled) return // track changed during retry — abort
+        setConvertedSrc(fresh)
+        media.src = fresh
+        media.load()
+        media.currentTime = resumeAt
+        if (wasPlaying) {
+          await media.play().catch((e) => {
+            if (e.name !== 'AbortError') console.error('play after retry failed:', e)
+          })
+        }
+      } catch (e) {
+        if (!cancelled) console.error('retry resolve failed:', e)
+      } finally {
+        if (!cancelled) setResolving(false)
+      }
+    }
+
+    media.addEventListener('error', handleError)
+    return () => {
+      cancelled = true
+      media.removeEventListener('error', handleError)
     }
   }, [track])
 

--- a/src/hooks/useDurations.ts
+++ b/src/hooks/useDurations.ts
@@ -22,15 +22,15 @@ export function useDurations() {
   const queue = useRef<string[]>([])
   const inFlight = useRef(0)
 
-  const dirs = useAppStore((s) => s.dirs)
-  const setDuration = useAppStore((s) => s.setDuration)
+  const dirs = useAppStore((s) => s.spaces.local.dirs)
+  const setDuration = useAppStore((s) => s.setLocalDuration)
 
   useEffect(() => {
     const allFiles = dirs.flatMap((d) => [
       ...d.files.map((f) => f.path),
       ...d.albums.flatMap((a) => a.files.map((f) => f.path)),
     ])
-    const existing = useAppStore.getState().durations
+    const existing = useAppStore.getState().spaces.local.durations
     queue.current = allFiles.filter((path) => !(path in existing))
     pump()
   }, [dirs])

--- a/src/hooks/useLocalFlatTracks.ts
+++ b/src/hooks/useLocalFlatTracks.ts
@@ -1,0 +1,21 @@
+import { useMemo } from 'react'
+import { useAppStore } from '../store'
+import { localTrack } from '../api/local'
+import { LocalTrack } from '../types'
+
+/**
+ * Flattened list of all local tracks across all dirs and albums,
+ * each tagged as a LocalTrack ready to be enqueued.
+ *
+ * The order matches the visual order in the Library — that's
+ * the order prev/next should follow when playing from local.
+ */
+export function useLocalFlatTracks(): LocalTrack[] {
+  const dirs = useAppStore((s) => s.spaces.local.dirs)
+  return useMemo(() => {
+    return dirs.flatMap((dir) => [
+      ...dir.files.map(localTrack),
+      ...dir.albums.flatMap((album) => album.files.map(localTrack)),
+    ])
+  }, [dirs])
+}

--- a/src/hooks/usePlayer.ts
+++ b/src/hooks/usePlayer.ts
@@ -4,7 +4,7 @@ import { useAppStore } from '../store'
 export function usePlayer() {
   const currentTrack = useAppStore((s) => s.currentTrack)
   const setCurrentTrack = useAppStore((s) => s.setCurrentTrack)
-  const dirs = useAppStore((s) => s.dirs)
+  const dirs = useAppStore((s) => s.spaces.local.dirs)
 
   const allTracks = useMemo(() => {
     return dirs.flatMap((dir) => [...dir.files, ...dir.albums.flatMap((album) => album.files)])

--- a/src/hooks/usePlayer.ts
+++ b/src/hooks/usePlayer.ts
@@ -1,26 +1,7 @@
-import { useMemo } from 'react'
 import { useAppStore } from '../store'
 
 export function usePlayer() {
-  const currentTrack = useAppStore((s) => s.currentTrack)
-  const setCurrentTrack = useAppStore((s) => s.setCurrentTrack)
-  const dirs = useAppStore((s) => s.spaces.local.dirs)
-
-  const allTracks = useMemo(() => {
-    return dirs.flatMap((dir) => [...dir.files, ...dir.albums.flatMap((album) => album.files)])
-  }, [dirs])
-
-  function next() {
-    if (!currentTrack) return
-    const idx = allTracks.findIndex((f) => f.path === currentTrack.path)
-    if (idx < allTracks.length - 1) setCurrentTrack(allTracks[idx + 1])
-  }
-
-  function prev() {
-    if (!currentTrack) return
-    const idx = allTracks.findIndex((f) => f.path === currentTrack.path)
-    if (idx > 0) setCurrentTrack(allTracks[idx - 1])
-  }
-
-  return { next, prev }
+  const playNext = useAppStore((s) => s.playNext)
+  const playPrev = useAppStore((s) => s.playPrev)
+  return { next: playNext, prev: playPrev }
 }

--- a/src/hooks/useScan.ts
+++ b/src/hooks/useScan.ts
@@ -11,26 +11,27 @@ export function useScan() {
     if (hasScanned.current) return
     hasScanned.current = true
 
-    const { setDirs, setScanMeta, setScanState, setLiveCount } = useAppStore.getState()
+    const { setLocalDirs, setLocalScanMeta, setLocalScanState, setLocalLiveCount } =
+      useAppStore.getState()
 
-    setScanState('scanning')
+    setLocalScanState('scanning')
 
     let unlistenProgress: (() => void) | undefined
     let unlistenCount: (() => void) | undefined
 
     async function setup() {
-      unlistenProgress = await listen<Directory[]>('scan_progress', event => {
-        setDirs(event.payload)
+      unlistenProgress = await listen<Directory[]>('scan_progress', (event) => {
+        setLocalDirs(event.payload)
       })
 
-      unlistenCount = await listen<number>('scan_count', event => {
-        setLiveCount(event.payload)
+      unlistenCount = await listen<number>('scan_count', (event) => {
+        setLocalLiveCount(event.payload)
       })
 
       const r = await invoke<ScanResult>('scan_media')
-      setDirs(r.directories)
-      setScanMeta(r.metadata)
-      setScanState('done')
+      setLocalDirs(r.directories)
+      setLocalScanMeta(r.metadata)
+      setLocalScanState('done')
     }
 
     setup()

--- a/src/hooks/useWaveform.ts
+++ b/src/hooks/useWaveform.ts
@@ -5,8 +5,12 @@ export function useWaveform() {
   const [waveformData, setWaveformData] = useState<number[]>([])
   const [loading, setLoading] = useState(false)
 
-  async function generateWaveform(path: string): Promise<void> {
+  async function generateWaveform(path: string | null): Promise<void> {
     setWaveformData([])
+    if (!path) {
+      setLoading(false)
+      return
+    }
     setLoading(true)
     try {
       const result = await invoke<{ samples: number[] }>('generate_waveform', { path })

--- a/src/spaces/LocalSpace.tsx
+++ b/src/spaces/LocalSpace.tsx
@@ -1,0 +1,11 @@
+import { Library } from '../components/Library'
+import { ScrollToActive } from '../components/ScrollToActivate'
+
+export function LocalSpace() {
+  return (
+    <div className="flex-1 relative overflow-hidden">
+      <ScrollToActive />
+      <Library />
+    </div>
+  )
+}

--- a/src/spaces/LocalSpaceHeader.tsx
+++ b/src/spaces/LocalSpaceHeader.tsx
@@ -1,0 +1,65 @@
+import { Search } from 'lucide-react'
+import { useAppStore } from '../store'
+
+export function LocalSpaceHeader() {
+  const query = useAppStore((s) => s.spaces.local.query)
+  const setQuery = useAppStore((s) => s.setLocalQuery)
+  const scanMeta = useAppStore((s) => s.spaces.local.scanMeta)
+  const scanState = useAppStore((s) => s.spaces.local.scanState)
+  const liveCount = useAppStore((s) => s.spaces.local.liveCount)
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* stats row */}
+      <div className="flex items-center gap-4 min-h-5">
+        {scanMeta && (
+          <div className="flex items-center gap-3 text-xs font-mono text-app-muted">
+            <span className="text-app-text">{scanMeta.total_files}</span>
+            <span>files</span>
+            <span className="text-app-muted">·</span>
+            <span className="text-app-text">{scanMeta.total_albums}</span>
+            <span>albums</span>
+            <span className="text-app-muted">·</span>
+            <span className="text-app-text">{scanMeta.total_directories}</span>
+            <span>dirs</span>
+            <span className="text-app-muted">·</span>
+            <span className="text-app-text">{scanMeta.duration_ms}ms</span>
+            {scanMeta.total_duplicates > 0 && (
+              <>
+                <span className="text-app-muted">·</span>
+                <span className="text-app-accent font-bold">
+                  {scanMeta.total_duplicates} duplicates
+                </span>
+              </>
+            )}
+          </div>
+        )}
+
+        {scanState === 'scanning' && (
+          <div className="flex items-center gap-2">
+            <div className="w-1.5 h-1.5 rounded-full bg-app-accent animate-pulse" />
+            <span className="text-xs text-app-muted font-mono">
+              scanning... {liveCount > 0 && `${liveCount} files`}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* search row */}
+      <div className="flex items-center gap-3 px-3 py-2 rounded border border-app-border hover:border-app-accent-dim transition-colors focus-within:border-app-accent">
+        <Search size={16} className="text-app-muted shrink-0" />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="type to search..."
+          className="bg-transparent text-app-text text-sm font-mono placeholder-app-muted outline-none flex-1"
+        />
+        <span className="text-xs font-mono text-app-muted shrink-0 hidden md:inline">
+          try <span className="text-app-secondary">shadow</span> or{' '}
+          <span className="text-app-secondary">drumcode</span>
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/spaces/OnlineSpace.tsx
+++ b/src/spaces/OnlineSpace.tsx
@@ -1,12 +1,114 @@
-import { Globe } from 'lucide-react'
+import { Globe, Loader2, AlertCircle } from 'lucide-react'
+import { selectCurrentTrack, useAppStore } from '../store'
+import { resultToTrack } from '../api/online'
+import { OnlineSearchResult } from '../types'
 
 export function OnlineSpace() {
+  const query = useAppStore((s) => s.spaces.online.query)
+  const results = useAppStore((s) => s.spaces.online.results)
+  const searchState = useAppStore((s) => s.spaces.online.searchState)
+  const searchError = useAppStore((s) => s.spaces.online.searchError)
+  const playTrackFromList = useAppStore((s) => s.playTrackFromList)
+
+  function handlePlay(result: OnlineSearchResult) {
+    const idx = results.findIndex((r) => r.video_id === result.video_id)
+    if (idx < 0) return
+    const queue = results.map(resultToTrack)
+    playTrackFromList(queue, idx)
+  }
+
   return (
-    <div className="flex-1 flex items-center justify-center">
-      <div className="flex flex-col items-center gap-3 text-app-muted">
-        <Globe size={48} />
-        <span className="text-sm font-mono">Online space — coming soon</span>
-      </div>
+    <div className="flex-1 flex flex-col min-h-0 overflow-y-auto px-4 py-4">
+      {searchState === 'idle' && !query.trim() && <EmptyState />}
+      {searchState === 'searching' && results.length === 0 && <LoadingState />}
+      {searchState === 'error' && <ErrorState message={searchError} />}
+      {searchState === 'done' && results.length === 0 && <NoResultsState query={query} />}
+      {results.length > 0 && (
+        <ul className="flex flex-col gap-1">
+          {results.map((r) => (
+            <ResultRow key={r.video_id} result={r} onPlay={() => handlePlay(r)} />
+          ))}
+        </ul>
+      )}
     </div>
   )
+}
+
+function ResultRow({ result, onPlay }: { result: OnlineSearchResult; onPlay: () => void }) {
+  const current = useAppStore(selectCurrentTrack)
+  const resolving = useAppStore((s) => s.resolving)
+  const isPlaying = current?.source === 'online' && current.videoId === result.video_id
+  const isResolving = isPlaying && resolving
+  return (
+    <li>
+      <button
+        onClick={onPlay}
+        className={`w-full flex items-center gap-3 px-2 py-2 rounded text-left transition-colors ${
+          isPlaying ? 'bg-app-selected' : 'hover:bg-app-hover'
+        }`}
+      >
+        <div className="w-12 h-12 rounded relative bg-app-skeleton overflow-hidden shrink-0">
+          {result.thumbnail && (
+            <img src={result.thumbnail} alt="" className="w-full h-full object-cover" />
+          )}
+          {isResolving && (
+            <div className="absolute inset-0 flex items-center justify-center bg-black/40">
+              <Loader2 size={20} className="animate-spin text-app-accent" />
+            </div>
+          )}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="text-sm text-app-text truncate">{result.title}</div>
+          <div className="text-xs text-app-secondary truncate">
+            {result.uploader ?? 'Unknown'}
+            {result.duration_secs > 0 && ` · ${formatDuration(result.duration_secs)}`}
+          </div>
+        </div>
+      </button>
+    </li>
+  )
+}
+
+function EmptyState() {
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center gap-3 text-app-muted">
+      <Globe size={48} />
+      <span className="text-sm font-mono">type to search youtube</span>
+    </div>
+  )
+}
+
+function LoadingState() {
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center gap-3 text-app-muted">
+      <Loader2 size={32} className="animate-spin" />
+      <span className="text-sm font-mono">searching...</span>
+    </div>
+  )
+}
+
+function ErrorState({ message }: { message: string | null }) {
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center gap-3 text-app-muted px-4 text-center">
+      <AlertCircle size={32} />
+      <span className="text-sm font-mono">search failed</span>
+      {message && (
+        <span className="text-xs text-app-muted/70 max-w-md wrap-break-word">{message}</span>
+      )}
+    </div>
+  )
+}
+
+function NoResultsState({ query }: { query: string }) {
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center gap-3 text-app-muted">
+      <span className="text-sm font-mono">no results for "{query}"</span>
+    </div>
+  )
+}
+
+function formatDuration(seconds: number): string {
+  const m = Math.floor(seconds / 60)
+  const s = Math.floor(seconds % 60)
+  return `${m}:${s.toString().padStart(2, '0')}`
 }

--- a/src/spaces/OnlineSpace.tsx
+++ b/src/spaces/OnlineSpace.tsx
@@ -1,0 +1,12 @@
+import { Globe } from 'lucide-react'
+
+export function OnlineSpace() {
+  return (
+    <div className="flex-1 flex items-center justify-center">
+      <div className="flex flex-col items-center gap-3 text-app-muted">
+        <Globe size={48} />
+        <span className="text-sm font-mono">Online space — coming soon</span>
+      </div>
+    </div>
+  )
+}

--- a/src/spaces/OnlineSpaceHeader.tsx
+++ b/src/spaces/OnlineSpaceHeader.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from 'react'
+import { Search } from 'lucide-react'
+import { useAppStore } from '../store'
+import { searchOnline } from '../api/online'
+
+const DEBOUNCE_MS = 400
+
+export function OnlineSpaceHeader() {
+  const query = useAppStore((s) => s.spaces.online.query)
+  const searchState = useAppStore((s) => s.spaces.online.searchState)
+  const setQuery = useAppStore((s) => s.setOnlineQuery)
+  const setResults = useAppStore((s) => s.setOnlineResults)
+  const setSearchState = useAppStore((s) => s.setOnlineSearchState)
+  const setSearchError = useAppStore((s) => s.setOnlineSearchError)
+
+  const searchSeq = useRef(0)
+
+  useEffect(() => {
+    const trimmed = query.trim()
+    if (!trimmed) {
+      setResults([])
+      setSearchState('idle')
+      setSearchError(null)
+      return
+    }
+
+    const seq = ++searchSeq.current
+    const timer = setTimeout(async () => {
+      setSearchState('searching')
+      setSearchError(null)
+      try {
+        const res = await searchOnline(trimmed)
+        if (seq !== searchSeq.current) return
+        setResults(res)
+        setSearchState('done')
+      } catch (e) {
+        if (seq !== searchSeq.current) return
+        setSearchError(typeof e === 'string' ? e : String(e))
+        setSearchState('error')
+      }
+    }, DEBOUNCE_MS)
+
+    return () => clearTimeout(timer)
+  }, [query, setResults, setSearchState, setSearchError])
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* status row — mirrors LocalSpaceHeader's stats row for layout parity */}
+      <div className="flex items-center gap-4 min-h-5">
+        {searchState === 'searching' && (
+          <div className="flex items-center gap-2">
+            <div className="w-1.5 h-1.5 rounded-full bg-app-accent animate-pulse" />
+            <span className="text-xs text-app-muted font-mono">searching...</span>
+          </div>
+        )}
+      </div>
+
+      {/* search row — identical styling to local for visual consistency */}
+      <div className="flex items-center gap-3 px-3 py-2 rounded border border-app-border hover:border-app-accent-dim transition-colors focus-within:border-app-accent">
+        <Search size={16} className="text-app-muted shrink-0" />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="search youtube..."
+          className="bg-transparent text-app-text text-sm font-mono placeholder-app-muted outline-none flex-1"
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/spaces/index.tsx
+++ b/src/spaces/index.tsx
@@ -1,0 +1,18 @@
+import { Disc3 } from 'lucide-react'
+import { JSX, ReactNode } from 'react'
+
+export interface Space {
+  id: string
+  name: string
+  icon: ReactNode
+  Component: () => JSX.Element
+}
+
+export const SPACES: Space[] = [
+  {
+    id: 'local',
+    name: 'Local',
+    icon: <Disc3 />,
+    Component: LocalSpace,
+  },
+]

--- a/src/spaces/index.tsx
+++ b/src/spaces/index.tsx
@@ -1,5 +1,7 @@
-import { Disc3 } from 'lucide-react'
+import { Globe, Home } from 'lucide-react'
 import { JSX, ReactNode } from 'react'
+import { LocalSpace } from './LocalSpace'
+import { OnlineSpace } from './OnlineSpace'
 
 export interface Space {
   id: string
@@ -12,7 +14,13 @@ export const SPACES: Space[] = [
   {
     id: 'local',
     name: 'Local',
-    icon: <Disc3 />,
+    icon: <Home size={20} />,
     Component: LocalSpace,
+  },
+  {
+    id: 'online',
+    name: 'Online',
+    icon: <Globe size={20} />,
+    Component: OnlineSpace,
   },
 ]

--- a/src/spaces/index.tsx
+++ b/src/spaces/index.tsx
@@ -2,12 +2,15 @@ import { Globe, Home } from 'lucide-react'
 import { JSX, ReactNode } from 'react'
 import { LocalSpace } from './LocalSpace'
 import { OnlineSpace } from './OnlineSpace'
+import { LocalSpaceHeader } from './LocalSpaceHeader'
+import { OnlineSpaceHeader } from './OnlineSpaceHeader'
 
 export interface Space {
   id: string
   name: string
   icon: ReactNode
   Component: () => JSX.Element
+  Header: () => JSX.Element
 }
 
 export const SPACES: Space[] = [
@@ -16,11 +19,13 @@ export const SPACES: Space[] = [
     name: 'Local',
     icon: <Home size={20} />,
     Component: LocalSpace,
+    Header: LocalSpaceHeader,
   },
   {
     id: 'online',
     name: 'Online',
     icon: <Globe size={20} />,
     Component: OnlineSpace,
+    Header: OnlineSpaceHeader,
   },
 ]

--- a/src/store.ts
+++ b/src/store.ts
@@ -3,11 +3,116 @@ import { Directory, MediaFile, ScanMetaData, ScanState } from './types'
 
 type Theme = 'dark' | 'light'
 
-const STORAGE_KEY = 'playmusic-collapsed'
+const COLLAPSED_KEY = 'playmusic-collapsed'
+
+interface LocalSpaceState {
+  // scan state
+  dirs: Directory[]
+  scanMeta: ScanMetaData | null
+  scanState: ScanState
+  liveCount: number
+
+  // ui state
+  query: string
+  durations: Record<string, number>
+
+  //collapsed albums
+  collapsed: Set<string>
+}
+
+interface AppState {
+  activeSpaceId: string
+
+  spaces: {
+    local: LocalSpaceState
+  }
+
+  // playback state
+  currentTrack: MediaFile | null
+  playing: boolean
+
+  // theme
+  theme: Theme
+
+  // actions
+  setActiveSpaceId: (id: string) => void
+  setCurrentTrack: (track: MediaFile | null) => void
+  setPlaying: (playing: boolean) => void
+  setTheme: (theme: Theme) => void
+
+  //local space actions
+  setLocalDirs: (dirs: Directory[]) => void
+  setLocalScanMeta: (meta: ScanMetaData | null) => void
+  setLocalScanState: (state: ScanState) => void
+  setLocalLiveCount: (count: number) => void
+  setLocalQuery: (query: string) => void
+  setLocalDuration: (path: string, duration: number) => void
+  toggleLocalCollapsed: (key: string) => void
+}
+
+export const useAppStore = create<AppState>((set) => ({
+  activeSpaceId: 'local',
+  currentTrack: null,
+  playing: false,
+  theme:
+    (typeof window !== 'undefined' && (localStorage.getItem('playmusic-theme') as Theme)) || 'dark',
+
+  spaces: {
+    local: {
+      dirs: [],
+      scanMeta: null,
+      scanState: 'idle',
+      liveCount: 0,
+      query: '',
+      durations: {},
+      collapsed: loadCollapsed(),
+    },
+  },
+
+  setActiveSpaceId: (id) => set({ activeSpaceId: id }),
+  setCurrentTrack: (currentTrack) => set({ currentTrack }),
+  setPlaying: (playing) => set({ playing }),
+  setTheme: (theme) => {
+    localStorage.setItem('playmusic-theme', theme)
+    document.documentElement.dataset.theme = theme
+    set({ theme })
+  },
+
+  setLocalDirs: (dirs) =>
+    set((s) => ({ spaces: { ...s.spaces, local: { ...s.spaces.local, dirs } } })),
+  setLocalScanMeta: (scanMeta) =>
+    set((s) => ({ spaces: { ...s.spaces, local: { ...s.spaces.local, scanMeta } } })),
+  setLocalScanState: (scanState) =>
+    set((s) => ({ spaces: { ...s.spaces, local: { ...s.spaces.local, scanState } } })),
+  setLocalLiveCount: (liveCount) =>
+    set((s) => ({ spaces: { ...s.spaces, local: { ...s.spaces.local, liveCount } } })),
+  setLocalQuery: (query) =>
+    set((s) => ({ spaces: { ...s.spaces, local: { ...s.spaces.local, query } } })),
+  setLocalDuration: (path, duration) =>
+    set((s) => ({
+      spaces: {
+        ...s.spaces,
+        local: {
+          ...s.spaces.local,
+          durations: { ...s.spaces.local.durations, [path]: duration },
+        },
+      },
+    })),
+  toggleLocalCollapsed: (key) =>
+    set((s) => {
+      const next = new Set(s.spaces.local.collapsed)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      localStorage.setItem(COLLAPSED_KEY, JSON.stringify([...next]))
+      return {
+        spaces: { ...s.spaces, local: { ...s.spaces.local, collapsed: next } },
+      }
+    }),
+}))
 
 function loadCollapsed(): Set<string> {
   try {
-    const saved = localStorage.getItem(STORAGE_KEY)
+    const saved = localStorage.getItem(COLLAPSED_KEY)
     if (!saved) return new Set()
     const parsed = JSON.parse(saved)
     if (!Array.isArray(parsed)) return new Set()
@@ -16,76 +121,6 @@ function loadCollapsed(): Set<string> {
     return new Set()
   }
 }
-interface AppState {
-  // scan state
-  dirs: Directory[]
-  scanMeta: ScanMetaData | null
-  scanState: ScanState
-  liveCount: number
-
-  // playback state
-  currentTrack: MediaFile | null
-  playing: boolean
-
-  // ui state
-  query: string
-  durations: Record<string, number>
-
-  // theme
-  theme: Theme
-
-  //collapsed albums
-  collapsed: Set<string>
-
-  // actions
-  setDirs: (dirs: Directory[]) => void
-  setScanMeta: (meta: ScanMetaData | null) => void
-  setScanState: (state: ScanState) => void
-  setLiveCount: (count: number) => void
-  setCurrentTrack: (track: MediaFile | null) => void
-  setPlaying: (playing: boolean) => void
-  setQuery: (query: string) => void
-  setDuration: (path: string, duration: number) => void
-  setTheme: (theme: Theme) => void
-  toggleCollapsed: (key: string) => void
-}
-
-export const useAppStore = create<AppState>((set) => ({
-  dirs: [],
-  scanMeta: null,
-  scanState: 'idle',
-  liveCount: 0,
-  currentTrack: null,
-  playing: false,
-  query: '',
-  durations: {},
-  theme:
-    (typeof window !== 'undefined' && (localStorage.getItem('playmusic-theme') as Theme)) || 'dark',
-  collapsed: loadCollapsed(),
-
-  setDirs: (dirs) => set({ dirs }),
-  setScanMeta: (scanMeta) => set({ scanMeta }),
-  setScanState: (scanState) => set({ scanState }),
-  setLiveCount: (liveCount) => set({ liveCount }),
-  setCurrentTrack: (currentTrack) => set({ currentTrack }),
-  setPlaying: (playing) => set({ playing }),
-  setQuery: (query) => set({ query }),
-  setDuration: (path, duration) =>
-    set((state) => ({ durations: { ...state.durations, [path]: duration } })),
-  setTheme: (theme) => {
-    localStorage.setItem('playmusic-theme', theme)
-    document.documentElement.dataset.theme = theme
-    set({ theme })
-  },
-  toggleCollapsed: (key) =>
-    set((state) => {
-      const next = new Set(state.collapsed)
-      if (next.has(key)) next.delete(key)
-      else next.add(key)
-      localStorage.setItem(STORAGE_KEY, JSON.stringify([...next]))
-      return { collapsed: next }
-    }),
-}))
 
 if (typeof window !== 'undefined') {
   const initial = (localStorage.getItem('playmusic-theme') as Theme) || 'dark'

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,12 @@
 import { create } from 'zustand'
-import { Directory, MediaFile, ScanMetaData, ScanState } from './types'
+import {
+  Directory,
+  ScanMetaData,
+  ScanState,
+  Track,
+  OnlineSearchResult,
+  OnlineSearchState,
+} from './types'
 
 type Theme = 'dark' | 'light'
 
@@ -16,8 +23,15 @@ interface LocalSpaceState {
   query: string
   durations: Record<string, number>
 
-  //collapsed albums
+  // collapsed albums
   collapsed: Set<string>
+}
+
+interface OnlineSpaceState {
+  query: string
+  results: OnlineSearchResult[]
+  searchState: OnlineSearchState
+  searchError: string | null
 }
 
 interface AppState {
@@ -25,22 +39,31 @@ interface AppState {
 
   spaces: {
     local: LocalSpaceState
+    online: OnlineSpaceState
   }
 
-  // playback state
-  currentTrack: MediaFile | null
+  // playback state (queue is the single source of truth)
+  queue: Track[]
+  queueIndex: number // -1 when nothing has been played yet
   playing: boolean
+  resolving: boolean
 
   // theme
   theme: Theme
 
   // actions
   setActiveSpaceId: (id: string) => void
-  setCurrentTrack: (track: MediaFile | null) => void
   setPlaying: (playing: boolean) => void
+  setResolving: (resolving: boolean) => void
   setTheme: (theme: Theme) => void
 
-  //local space actions
+  // queue actions
+  playTrackFromList: (tracks: Track[], index: number) => void
+  playNext: () => void
+  playPrev: () => void
+  clearQueue: () => void
+
+  // local space actions
   setLocalDirs: (dirs: Directory[]) => void
   setLocalScanMeta: (meta: ScanMetaData | null) => void
   setLocalScanState: (state: ScanState) => void
@@ -48,12 +71,21 @@ interface AppState {
   setLocalQuery: (query: string) => void
   setLocalDuration: (path: string, duration: number) => void
   toggleLocalCollapsed: (key: string) => void
+
+  // online space actions
+  setOnlineQuery: (query: string) => void
+  setOnlineResults: (results: OnlineSearchResult[]) => void
+  setOnlineSearchState: (state: OnlineSearchState) => void
+  setOnlineSearchError: (error: string | null) => void
+  resetOnlineSearch: () => void
 }
 
 export const useAppStore = create<AppState>((set) => ({
   activeSpaceId: 'local',
-  currentTrack: null,
+  queue: [],
+  queueIndex: -1,
   playing: false,
+  resolving: false,
   theme:
     (typeof window !== 'undefined' && (localStorage.getItem('playmusic-theme') as Theme)) || 'dark',
 
@@ -67,16 +99,40 @@ export const useAppStore = create<AppState>((set) => ({
       durations: {},
       collapsed: loadCollapsed(),
     },
+    online: {
+      query: '',
+      results: [],
+      searchState: 'idle',
+      searchError: null,
+    },
   },
 
   setActiveSpaceId: (id) => set({ activeSpaceId: id }),
-  setCurrentTrack: (currentTrack) => set({ currentTrack }),
   setPlaying: (playing) => set({ playing }),
+  setResolving: (resolving) => set({ resolving }),
   setTheme: (theme) => {
     localStorage.setItem('playmusic-theme', theme)
     document.documentElement.dataset.theme = theme
     set({ theme })
   },
+  playTrackFromList: (tracks, index) => {
+    if (tracks.length === 0 || index < 0 || index >= tracks.length) return
+    set({ queue: tracks, queueIndex: index })
+  },
+
+  playNext: () =>
+    set((s) => {
+      if (s.queueIndex < 0 || s.queueIndex >= s.queue.length - 1) return s
+      return { queueIndex: s.queueIndex + 1 }
+    }),
+
+  playPrev: () =>
+    set((s) => {
+      if (s.queueIndex <= 0) return s
+      return { queueIndex: s.queueIndex - 1 }
+    }),
+
+  clearQueue: () => set({ queue: [], queueIndex: -1 }),
 
   setLocalDirs: (dirs) =>
     set((s) => ({ spaces: { ...s.spaces, local: { ...s.spaces.local, dirs } } })),
@@ -108,6 +164,28 @@ export const useAppStore = create<AppState>((set) => ({
         spaces: { ...s.spaces, local: { ...s.spaces.local, collapsed: next } },
       }
     }),
+
+  setOnlineQuery: (query) =>
+    set((s) => ({ spaces: { ...s.spaces, online: { ...s.spaces.online, query } } })),
+  setOnlineResults: (results) =>
+    set((s) => ({ spaces: { ...s.spaces, online: { ...s.spaces.online, results } } })),
+  setOnlineSearchState: (searchState) =>
+    set((s) => ({ spaces: { ...s.spaces, online: { ...s.spaces.online, searchState } } })),
+  setOnlineSearchError: (searchError) =>
+    set((s) => ({ spaces: { ...s.spaces, online: { ...s.spaces.online, searchError } } })),
+  resetOnlineSearch: () =>
+    set((s) => ({
+      spaces: {
+        ...s.spaces,
+        online: {
+          ...s.spaces.online,
+          query: '',
+          results: [],
+          searchState: 'idle',
+          searchError: null,
+        },
+      },
+    })),
 }))
 
 function loadCollapsed(): Set<string> {
@@ -125,4 +203,9 @@ function loadCollapsed(): Set<string> {
 if (typeof window !== 'undefined') {
   const initial = (localStorage.getItem('playmusic-theme') as Theme) || 'dark'
   document.documentElement.dataset.theme = initial
+}
+
+export const selectCurrentTrack = (s: ReturnType<typeof useAppStore.getState>): Track | null => {
+  if (s.queueIndex < 0 || s.queueIndex >= s.queue.length) return null
+  return s.queue[s.queueIndex]
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,3 +56,12 @@ export interface ScanResult {
 }
 
 export type ScanState = 'idle' | 'scanning' | 'done'
+export type OnlineSearchState = 'idle' | 'searching' | 'done' | 'error'
+
+export interface OnlineSearchResult {
+  video_id: string
+  title: string
+  duration_secs: number
+  thumbnail: string | null
+  uploader: string | null
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,28 @@ export interface MediaFile {
   created_at: number
 }
 
+export interface LocalTrack extends MediaFile {
+  source: 'local'
+}
+
+export interface OnlineTrack {
+  source: 'online'
+  videoId: string
+  // mirror MediaFile field names so existing consumers Just Work
+  path: string // = videoId, used as stable identifier (NOT a filesystem path)
+  name: string // video title
+  ext: string // 'webm' | 'm4a' | 'mp4' — whatever yt-dlp's bestaudio returns
+  duration_secs: number // from search metadata
+  size_bytes: number // 0 (unknown for streams)
+  art_path: string | null // YouTube thumbnail URL (https://...)
+  created_at: number // upload timestamp from yt-dlp, or Date.now()
+
+  // online-only
+  uploader?: string
+}
+
+export type Track = LocalTrack | OnlineTrack
+
 export interface Album {
   name: string
   files: MediaFile[]
@@ -21,7 +43,7 @@ export interface Directory {
 }
 
 export interface ScanMetaData {
-  duration_ms : number
+  duration_ms: number
   total_files: number
   total_albums: number
   total_directories: number

--- a/src/utils/resolveArt.ts
+++ b/src/utils/resolveArt.ts
@@ -1,0 +1,7 @@
+import { convertFileSrc } from '@tauri-apps/api/core'
+import { Track } from '../types'
+
+export function resolveArt(track: Track): string | null {
+  if (!track.art_path) return null
+  return track.source === 'local' ? convertFileSrc(track.art_path) : track.art_path
+}


### PR DESCRIPTION
# Online Space + Queue-Based Playback

## Summary

Added an Online space backed by yt-dlp, and refactored playback to use a unified queue that's source-agnostic.

## Backend (Rust)

- New sidecar: yt-dlp bundled at `src-tauri/binaries/yt-dlp-<target-triple>`
- New module `src-tauri/src/online.rs` with two commands:
  - `search_online(query)` — runs `ytsearch10:` via yt-dlp `--flat-playlist`, returns search results
  - `resolve_stream(video_id)` — returns a fresh `bestaudio` stream URL (resolved lazily; URLs expire)
- `tauri-plugin-shell` registered in `lib.rs`
- `tauri.conf.json` — `externalBin` entry for yt-dlp
- `capabilities/default.json` — `shell:allow-execute` permission for the sidecar

## Types

- New discriminated `Track` union: `LocalTrack | OnlineTrack`, both sharing `MediaFile`-shaped fields plus a `source` discriminator
- New `OnlineSearchResult` and `OnlineSearchState` types

## Store

- New `online` slice mirroring `local`: `query`, `results`, `searchState`, `searchError`
- `currentTrack` removed as a stored field — now derived via `selectCurrentTrack` selector
- New queue-based playback state: `queue: Track[]`, `queueIndex: number`
- New actions: `playTrackFromList`, `playNext`, `playPrev`, `clearQueue`
- New global `resolving: boolean` for online stream resolution loading state

## Frontend

- **Header refactor** — Header now renders shared chrome (theme toggle) and a slot for the active space's header component. Each space provides its own `Header` component via the `SPACES` registry.
- **`OnlineSpaceHeader`** — search input with 400ms debounce and stale-result protection via a sequence ref
- **`OnlineSpace`** — results list with thumbnails, currently-playing highlight, and per-row resolving spinner
- **`useAudioPlayer`** — async track loading with cancellation guard, branches on `track.source` (local → `convertFileSrc`, online → `resolveStream`); handles stream URL expiry by listening for `error` events and re-resolving with a 10s cooldown
- **`useWaveform`** — guarded against non-local tracks (online tracks pass `null` from caller)
- **`usePlayer`** — thinned to a wrapper around store queue actions
- **`useLocalFlatTracks`** — new hook providing the flat library list, used by both the click handler and queue navigation
- **PlayerBar** — play/pause button shows a spinner and disables itself while `resolving`

## API helpers

- `src/api/online.ts` — `searchOnline`, `resolveStream`, `resultToTrack`
- `src/api/local.ts` — `localTrack` helper to tag a `MediaFile` as `LocalTrack`

## Known follow-ups (not in this branch)

- Per-space playback ownership (currently shared queue across spaces)
- yt-dlp update mechanism (currently pinned to bundled binary)