### PR TITLE
docs: clarify PlayMusic relationship and contributor guide

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,11 +1,57 @@
 # Architecture
 
+## Scope
+
+This document describes `musical-palm-tree`, the Tauri desktop companion project
+in the PlayMusic ecosystem. The main PlayMusic repository focuses on a
+Go/Bubble Tea terminal player; this repository explores the same media-player
+domain through a desktop UI, React state, Tauri IPC, and Rust-backed media work.
+
+The two projects share learning-oriented open-source goals and media-player
+ideas, while using different stacks and interaction models.
+
+| Area | PlayMusic | musical-palm-tree |
+| --- | --- | --- |
+| Interface | Bubble Tea TUI | Desktop WebView UI |
+| Main stack | Go | Tauri, React, TypeScript, Rust |
+| Learning focus | Go packages, TUI, playback | React state, desktop UX, IPC, Rust commands |
+| Video path | External player handoff | Embedded video pane |
+| Contribution style | Focused PRs | Fork-friendly experiments + focused PRs |
+
 ## Overview
 
-PlayMusic is a Tauri 2 desktop app with a React frontend and Rust backend.
+`musical-palm-tree` is a Tauri 2 desktop app with a React frontend and Rust backend.
 The app is structured around the concept of "spaces" — distinct music sources
 (local filesystem, online streaming, etc.) that share common playback
 infrastructure.
+
+## How To Read This Project
+
+If you are new to this codebase, start with:
+
+1. `src/App.tsx` - top-level layout and persistent player shell
+2. `src/spaces/index.tsx` - registered content spaces
+3. `src/spaces/LocalSpace.tsx` - local media library flow
+4. `src/spaces/OnlineSpace.tsx` - online search results flow
+5. `src/components/PlayerBar.tsx` - playback controls, waveform, and media elements
+6. `src/store.ts` - global Zustand state and queue model
+7. `src-tauri/src/lib.rs` - registered Rust commands
+8. `src-tauri/src/scanner.rs` - local filesystem scanning
+9. `src-tauri/src/waveform.rs` - waveform generation
+
+The main mental model is: React owns UI and state, Tauri IPC connects it to
+Rust, and Rust handles heavier filesystem and media work.
+
+## Main User Flow
+
+1. The app opens with a desktop shell: titlebar, header, sidebar, active space,
+   video pane, and player bar.
+2. The active space renders either local media or online search.
+3. Local media is scanned through the Rust `scan_media` command.
+4. Scan progress streams back to React via Tauri events.
+5. Selecting a track updates the global queue in Zustand.
+6. `PlayerBar` owns playback controls, waveform display, and audio/video
+   elements.
 
 ## Tech Stack
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,15 +2,16 @@
 
 ## Scope
 
-This document describes `musical-palm-tree`, the Tauri desktop companion project
-in the PlayMusic ecosystem. The main PlayMusic repository focuses on a
+This document describes PlayMusic Desktop, the Tauri desktop companion project
+in the PlayMusic ecosystem. The repository is currently named `musical-palm-tree`.
+The main PlayMusic repository focuses on a
 Go/Bubble Tea terminal player; this repository explores the same media-player
 domain through a desktop UI, React state, Tauri IPC, and Rust-backed media work.
 
 The two projects share learning-oriented open-source goals and media-player
 ideas, while using different stacks and interaction models.
 
-| Area | PlayMusic | musical-palm-tree |
+| Area | PlayMusic | PlayMusic Desktop |
 | --- | --- | --- |
 | Interface | Bubble Tea TUI | Desktop WebView UI |
 | Main stack | Go | Tauri, React, TypeScript, Rust |
@@ -20,7 +21,7 @@ ideas, while using different stacks and interaction models.
 
 ## Overview
 
-`musical-palm-tree` is a Tauri 2 desktop app with a React frontend and Rust backend.
+PlayMusic Desktop is a Tauri 2 desktop app with a React frontend and Rust backend.
 The app is structured around the concept of "spaces" — distinct music sources
 (local filesystem, online streaming, etc.) that share common playback
 infrastructure.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# musical-palm-tree
+# PlayMusic Desktop
 
 A cross-platform desktop media player built with Tauri, React, and Rust, and a companion project in the PlayMusic ecosystem. It scans your home directory for audio and video files, groups them by folder, and plays them with a keyboard-driven waveform UI inspired by terminal aesthetics.
 
 ## Relationship to PlayMusic
 
-`musical-palm-tree` is a desktop companion project in the PlayMusic ecosystem.
+PlayMusic Desktop is a desktop companion project in the PlayMusic ecosystem. The repository is currently named `musical-palm-tree`.
 
 The main [PlayMusic](https://github.com/samuaks/playmusic) repository focuses on a Go/Bubble Tea terminal media player. This project explores the same media-player domain through a desktop stack: Tauri, React, TypeScript, and Rust.
 
 Together, the projects offer complementary learning paths:
 
 - PlayMusic: Go, terminal UI, playback architecture, CLI/TUI workflows
-- musical-palm-tree: desktop UX, React state, Tauri IPC, Rust-backed media processing
+- PlayMusic Desktop: desktop UX, React state, Tauri IPC, Rust-backed media processing
 
 This repository is especially fork-friendly: contributors can experiment with UI, playback, scanning, and desktop interaction ideas in their own forks, then bring small, well-explained improvements back through pull requests.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
-# PlayMusic
+# musical-palm-tree
 
-A cross-platform media player built with Tauri, React, and Rust. Scans your home directory for audio and video files, groups them by folder, and plays them with a keyboard-driven waveform UI inspired by terminal aesthetics.
+A cross-platform desktop media player built with Tauri, React, and Rust, and a companion project in the PlayMusic ecosystem. It scans your home directory for audio and video files, groups them by folder, and plays them with a keyboard-driven waveform UI inspired by terminal aesthetics.
+
+## Relationship to PlayMusic
+
+`musical-palm-tree` is a desktop companion project in the PlayMusic ecosystem.
+
+The main [PlayMusic](https://github.com/samuaks/playmusic) repository focuses on a Go/Bubble Tea terminal media player. This project explores the same media-player domain through a desktop stack: Tauri, React, TypeScript, and Rust.
+
+Together, the projects offer complementary learning paths:
+
+- PlayMusic: Go, terminal UI, playback architecture, CLI/TUI workflows
+- musical-palm-tree: desktop UX, React state, Tauri IPC, Rust-backed media processing
+
+This repository is especially fork-friendly: contributors can experiment with UI, playback, scanning, and desktop interaction ideas in their own forks, then bring small, well-explained improvements back through pull requests.
 
 ## Screenshots
 
@@ -62,6 +75,7 @@ A cross-platform media player built with Tauri, React, and Rust. Scans your home
 | 13 | Network streaming from custom API | Feature | Researching |
 | 14 | Mobile builds (Tauri 2.0 iOS / Android) | Feature | Researching |
 | 15 | Headphone removal auto-pause | Feature | Not possible without native platform APIs |
+| 16 | Contributor-friendly fork workflow docs | Docs | Planned |
 
 ## Usage
 
@@ -76,6 +90,22 @@ bun run tauri build
 ```
 
 Produces platform-native installers in `src-tauri/target/release/bundle/`.
+
+## Learning and Forks
+
+This project is designed to be useful as a learning open-source codebase. Forks are welcome as a normal way to explore ideas before they are ready for a focused pull request.
+
+Good fork-sized experiments include:
+
+- trying a new library layout
+- improving player controls
+- changing the video pane UX
+- experimenting with online search
+- improving scan performance
+- refining themes and visual states
+- adding small Rust/Tauri commands
+
+When bringing work back, prefer small pull requests with a clear explanation, screenshots for UI changes, and simple verification notes.
 
 ## Hotkeys
 
@@ -132,4 +162,3 @@ Produces platform-native installers in `src-tauri/target/release/bundle/`.
 The browser's `AudioContext.decodeAudioData` loads the full file into memory as raw PCM before any processing can begin. A 38-minute stereo track decodes to roughly 800MB of floats, which crashes the WebView process on large files.
 
 Moving waveform generation to Rust with `symphonia` bounded memory usage to the decoded portion (first 60s) regardless of file size, while also producing cleaner output via native format parsers.
-


### PR DESCRIPTION
## Summary

- Clarifies `musical-palm-tree` as a Tauri/React/Rust desktop companion project in the PlayMusic ecosystem.
- Adds README context about the relationship to the main Go/Bubble Tea PlayMusic project.
- Adds fork-friendly learning guidance for contributors.
- Expands `ARCHITECTURE.md` with project scope, a comparison table, a “how to read this project” guide, and the main user flow.

## Verification

- Documentation-only change.
- Ran `git diff --check`.
